### PR TITLE
[client] 지역별 잼 조회 기능 구현

### DIFF
--- a/client/src/Components/Category/JamCard.js
+++ b/client/src/Components/Category/JamCard.js
@@ -32,6 +32,9 @@ const openedJam = css`
 const closedJam = css`
   background-color: ${palette.colorJamClose};
 `;
+const realTimeJam = css`
+  background-color: ${palette.colorJamRealtime};
+`;
 
 const coverImage = css`
   width: 100%;
@@ -90,7 +93,7 @@ const JamCard = ({ jam }) => {
           ) : (
             <div className={openedJam}>모집중</div>
           )}
-          {jam.realTime ? <div>실시간</div> : null}
+          {jam.realTime ? <div className={realTimeJam}>실시간</div> : null}
         </div>
         <div className={info}>
           <div className={infoTop}>

--- a/client/src/Components/Category/JamCard.js
+++ b/client/src/Components/Category/JamCard.js
@@ -19,17 +19,10 @@ const box = css`
 const topArea = css`
   display: flex;
   div {
-    background-color: blueviolet;
     border-radius: 10px;
     padding: 5px 15px;
     font-size: 12px;
     margin-right: 5px;
-  }
-  div:nth-child(1) {
-    background-color: ${palette.colorJamOpen};
-  }
-  div:nth-child(2) {
-    background-color: ${palette.colorJamRealtime};
   }
 `;
 
@@ -80,16 +73,22 @@ const infoBottom = css`
 `;
 
 const JamCard = ({ jam }) => {
+  let isCompleteJam;
+  if (jam.completeStatus === 'FALSE') {
+    isCompleteJam = false;
+  } else if (jam.completeStatus === 'TRUE') {
+    isCompleteJam = true;
+  }
   return (
     <div className={box}>
       <div className={coverImage} />
       <div className={bottomArea}>
         <p>{jam.title}</p>
         <div className={topArea}>
-          {jam.completeStatus === 'FALSE' ? (
-            <div className={openedJam}>모집중</div>
-          ) : (
+          {isCompleteJam ? (
             <div className={closedJam}>마감</div>
+          ) : (
+            <div className={openedJam}>모집중</div>
           )}
           {jam.realTime ? <div>실시간</div> : null}
         </div>

--- a/client/src/Components/Category/LongJamCard.js
+++ b/client/src/Components/Category/LongJamCard.js
@@ -26,6 +26,9 @@ const openedJam = css`
 const closedJam = css`
   background-color: ${palette.colorJamClose};
 `;
+const realTimeJam = css`
+  background-color: ${palette.colorJamRealtime};
+`;
 
 const coverImage = css`
   width: 60px;
@@ -90,7 +93,7 @@ const LongJamCard = ({ jam }) => {
           ) : (
             <div className={openedJam}>모집중</div>
           )}
-          {jam.realTime ? <div>실시간</div> : null}
+          {jam.realTime ? <div className={realTimeJam}>실시간</div> : null}
         </div>
 
         <div className={bottomInfo}>

--- a/client/src/Components/Category/LongJamCard.js
+++ b/client/src/Components/Category/LongJamCard.js
@@ -1,9 +1,11 @@
+/* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
 // import { BiCategory } from 'react-icons/bi';
 import { BsClockFill, BsPeopleFill } from 'react-icons/bs';
 import { ImLocation } from 'react-icons/im';
 // import { FaUserCircle } from 'react-icons/fa';
 import { palette } from '../../Styles/theme';
+import jamElapsedTime from '../userComp/JamElapsedTime';
 
 const box = css`
   display: flex;
@@ -16,6 +18,13 @@ const box = css`
   align-items: center;
   padding: 10px 15px;
   margin: 10px;
+`;
+
+const openedJam = css`
+  background-color: ${palette.colorJamOpen};
+`;
+const closedJam = css`
+  background-color: ${palette.colorJamClose};
 `;
 
 const coverImage = css`
@@ -41,7 +50,6 @@ const topInfo = css`
   }
   div {
     border-radius: 10px;
-    background-color: ${palette.colorJamOpen};
     padding: 3px 20px;
     margin: 0px 5px;
     font-size: 12px;
@@ -64,28 +72,39 @@ const bottomInfo = css`
   }
 `;
 
-const LongJamCard = () => {
+const LongJamCard = ({ jam }) => {
+  let isCompleteJam;
+  if (jam.completeStatus === 'FALSE') {
+    isCompleteJam = false;
+  } else if (jam.completeStatus === 'TRUE') {
+    isCompleteJam = true;
+  }
   return (
     <div className={box}>
       <div className={coverImage} />
       <div className={info}>
         <div className={topInfo}>
-          <p>토익스터디하실분</p>
-          <div>모집중</div>
+          <p>{jam.title}</p>
+          {isCompleteJam ? (
+            <div className={closedJam}>마감</div>
+          ) : (
+            <div className={openedJam}>모집중</div>
+          )}
+          {jam.realTime ? <div>실시간</div> : null}
         </div>
 
         <div className={bottomInfo}>
           <div>
             <BsClockFill />
-            <p>1분전</p>
+            <p>{jamElapsedTime(jam.createdAt)}</p>
           </div>
           <div>
             <BsPeopleFill />
-            <p>1분전</p>
+            <p>{jam.currentPpl}명</p>
           </div>
           <div>
             <ImLocation />
-            <p>스타벅스 마곡역점</p>
+            <p>{jam.location}</p>
           </div>
         </div>
       </div>

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -1,21 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
-import { location } from '../../Atom/atoms';
+import { coordinate, location } from '../../Atom/atoms';
 
 // 33.450701, 126.570667
 const { kakao } = window;
 const Map = () => {
   // 마곡
-  // const [latitude] = useState(37.5602098);
-  // const [longitude] = useState(126.825479);
+  const [latitude] = useState(37.5602098);
+  const [longitude] = useState(126.825479);
 
   // 제주
-  const [latitude] = useState(33.450701);
-  const [longitude] = useState(126.570667);
+  // const [latitude] = useState(33.450701);
+  // const [longitude] = useState(126.570667);
 
   // 장소 검색 객체를 생성합니다
   // const ps = new kakao.maps.services.Places();
   const [currentLocation] = useRecoilState(location);
+  const [currentCoordinate, setCurrentCoordinate] = useRecoilState(coordinate);
   // 좌표로 주소 얻기
   function getMap() {
     const container = document.getElementById('map'); // 지도를 표시할 div
@@ -28,16 +29,24 @@ const Map = () => {
     // 지도가 이동, 확대, 축소로 인해 중심좌표가 변경되면 마지막 파라미터로 넘어온 함수를 호출하도록 이벤트를 등록합니다
     kakao.maps.event.addListener(map, 'center_changed', function () {
       // 지도의  레벨을 얻어옵니다
-      const level = map.getLevel();
+      // const level = map.getLevel();
 
       // 지도의 중심좌표를 얻어옵니다
       const latlng = map.getCenter();
+      setCurrentCoordinate({
+        latitude: latlng.getLat(),
+        longitude: latlng.getLng(),
+      });
 
-      const message = `지도 레벨은 ${level} 이고 중심 좌표는 위도 ${latlng.getLat()}, 경도 ${latlng.getLng()}입니다`;
-      console.log(message);
+      // const message = `지도 레벨은 ${level} 이고 중심 좌표는 위도 ${latlng.getLat()}, 경도 ${latlng.getLng()}입니다`;
+      // console.log(message);
     });
     return map;
   }
+
+  useState(() => {
+    console.log('currentCoordinate', currentCoordinate);
+  }, [currentCoordinate]);
 
   // 키워드 검색 완료 시 호출되는 콜백함수 입니다
   // function placesSearchCB(data, status) {

--- a/client/src/Components/NoData.js
+++ b/client/src/Components/NoData.js
@@ -14,11 +14,37 @@ const container = css`
   padding: 20px 100px;
 `;
 const text1 = css`
+  word-break: keep-all;
   text-align: center;
   font-size: 24px;
   margin: 5px;
 `;
 const text2 = css`
+  word-break: keep-all;
+  text-align: center;
+  font-size: large;
+  margin: 15px;
+`;
+
+const containerHome = css`
+  display: flex;
+  flex-direction: column;
+  height: 140px;
+  overflow: hidden;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid ${palette.border};
+  border-radius: 10px;
+  margin: 20px;
+  padding: 20px 100px;
+`;
+const text1Home = css`
+  word-break: keep-all;
+  text-align: center;
+  font-size: 24px;
+  margin: 5px;
+`;
+const text2Home = css`
   word-break: keep-all;
   text-align: center;
   font-size: large;
@@ -38,6 +64,15 @@ export const NoCategoryData = () => {
   return (
     <div className={container}>
       <div className={text1}>현재 카테고리의 잼이 없습니다.</div>
+    </div>
+  );
+};
+
+export const NoNearyByData = () => {
+  return (
+    <div className={containerHome}>
+      <div className={text1Home}>근처에 잼이 없습니다.</div>
+      <div className={text2Home}>주소 재설정 또는 지도를 움직여보세요!</div>
     </div>
   );
 };

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -2,13 +2,15 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 // import palette from '../Styles/theme';
 import { useRecoilState } from 'recoil';
 import Sidebar from '../Components/Sidebar';
 import LongJamCard from '../Components/Category/LongJamCard';
 import Map from '../Components/Map/Map';
-import { location } from '../Atom/atoms';
+import { location, coordinate } from '../Atom/atoms';
+import { fetchJamRead } from '../Utils/fetchJam';
+import { NoNearyByData } from '../Components/NoData';
 
 const pagewithSidebar = css`
   display: flex;
@@ -26,7 +28,7 @@ const home = css`
 const mainArea = css`
   display: flex;
   margin: 10px;
-  justify-content: space-around;
+  /* justify-content: space-around; */
 `;
 
 const map = css`
@@ -46,6 +48,23 @@ const list = css`
 
 const Home = () => {
   const [currentLocation] = useRecoilState(location);
+  const [currentCoordinate] = useRecoilState(coordinate);
+  const [jamData, setJamData] = useState([]);
+
+  useEffect(() => {
+    console.log(currentCoordinate.latitude);
+    console.log(currentCoordinate.longitude);
+    const endpoint = `/location?lat=${currentCoordinate.latitude}&lon=${currentCoordinate.longitude}`;
+    console.log(endpoint);
+    const locateJams = fetchJamRead(endpoint);
+    locateJams.then(data => {
+      setJamData(data.data);
+    });
+  }, [currentCoordinate]);
+
+  useEffect(() => {
+    console.log(jamData);
+  }, [jamData]);
 
   return (
     <div className={pagewithSidebar}>
@@ -61,11 +80,18 @@ const Home = () => {
           <div className={map}>
             <Map />
           </div>
-          <div className={list}>
-            <LongJamCard />
-            <LongJamCard />
-            <LongJamCard />
-          </div>
+          {jamData.length ? (
+            <div className={list}>
+              {jamData &&
+                jamData.map(jam => {
+                  return <LongJamCard key={jam.jamId} jam={jam} />;
+                })}
+            </div>
+          ) : (
+            <div className={list}>
+              <NoNearyByData />
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- Home 화면에 지역별 잼 데이터를 LongCard 각각 알맞은 위치에 추가했습니다.
- 지도상의 위치가 변경될 때마다 해당 지역에 맞는 잼 데이터를 가져오는 기능을 추가했습니다.
- NoData.js에 NoNearByData를 추가해 현재 지도상의 위치에 데이터가 없을 경우 빈화면이 보이지 않도록 수정했습니다.
- JamCard와 LongJamCard의 마감/모집중/실시간 색상 적용이 되지 않는 문제를 수정했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/53070295/205003301-ff048f48-4d4e-440b-b80f-a12052a58cdc.png)
![image](https://user-images.githubusercontent.com/53070295/205003490-4a626dc2-4d91-430c-9b48-fc97a0e9d222.png)

