### PR TITLE
[server] 유저에서 참여자 프로필 이미지 가져오기

### DIFF
--- a/server/src/main/java/com/jamit/jam/dto/ResponseParticipantDto.java
+++ b/server/src/main/java/com/jamit/jam/dto/ResponseParticipantDto.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class ResponseParticipantDto {
     private Long memberId;
     private String nickname;
-    private String image;
+    private String profileImage;
 }

--- a/server/src/main/java/com/jamit/jam/mapper/JamMapper.java
+++ b/server/src/main/java/com/jamit/jam/mapper/JamMapper.java
@@ -38,6 +38,7 @@ public interface JamMapper {
 
     @Mapping(source = "member.memberId", target = "memberId")
     @Mapping(source = "member.nickname", target = "nickname")
+    @Mapping(source = "member.profileImage", target = "profileImage")
     ResponseParticipantDto participantToParticipantListDto(JamParticipant jamParticipant);
 
 //    @IterableMapping(qualifiedByName = "jamList")


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 유저 정보 수정에서 profileImage 입력
![image](https://user-images.githubusercontent.com/92264867/205291773-4aba8e89-033a-41e0-9af1-bc8c5282732f.png)

- 잼 상세 조회 participantList(20~26번 줄)에서 확인
![image](https://user-images.githubusercontent.com/92264867/205291865-52523c09-c089-45ad-addc-ca734f2c2d4b.png)

## 스크린샷
구현한 기능에 대한 이미지 파일을 첨부해주세요.

