### PR TITLE
[client] 검색, 카테고리, 잼 상세 연동

### DIFF
--- a/client/src/Components/Category/CategoryResult.js
+++ b/client/src/Components/Category/CategoryResult.js
@@ -58,17 +58,13 @@ const noDataContainer = css`
 const Category = () => {
   const [currentCategory] = useRecoilState(selectedCategory);
   const searchText = sessionStorage.getItem('searchText');
-  console.log(searchText);
   const [jamData, setJamData] = useState([]);
   const [filteredData, setFilteredData] = useState('');
   const filterButtonGroup = ['전체', '실시간 잼', '스터디 잼'];
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log(currentCategory);
     if (currentCategory.label === '내주변') navigate('/home');
-  }, [currentCategory]);
-  useEffect(() => {
     if (searchText) {
       const Jams = fetchJamSearch(searchText);
       Jams.then(data => {

--- a/client/src/Components/Category/CategoryResult.js
+++ b/client/src/Components/Category/CategoryResult.js
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 import { ButtonGroup, Button } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 import { fetchJamRead, fetchJamSearch } from '../../Utils/fetchJam';
 import { theme } from '../../Styles/theme';
 import Sidebar from '../Sidebar';
@@ -61,7 +62,12 @@ const Category = () => {
   const [jamData, setJamData] = useState([]);
   const [filteredData, setFilteredData] = useState('');
   const filterButtonGroup = ['전체', '실시간 잼', '스터디 잼'];
+  const navigate = useNavigate();
 
+  useEffect(() => {
+    console.log(currentCategory);
+    if (currentCategory.label === '내주변') navigate('/home');
+  }, [currentCategory]);
   useEffect(() => {
     if (searchText) {
       const Jams = fetchJamSearch(searchText);

--- a/client/src/Components/Category/JamCard.js
+++ b/client/src/Components/Category/JamCard.js
@@ -1,9 +1,12 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
 // import { BiCategory } from 'react-icons/bi';
 import { BsClockFill, BsPeopleFill } from 'react-icons/bs';
 import { ImLocation } from 'react-icons/im';
 // import { FaUserCircle } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
 import { palette } from '../../Styles/theme';
 import jamElapsedTime from '../userComp/JamElapsedTime';
 
@@ -14,6 +17,7 @@ const box = css`
   padding: 10px 10px 20px 10px;
   margin: 10px 30px;
   border-radius: 10px;
+  cursor: pointer;
 `;
 
 const topArea = css`
@@ -82,8 +86,12 @@ const JamCard = ({ jam }) => {
   } else if (jam.completeStatus === 'TRUE') {
     isCompleteJam = true;
   }
+  const navigate = useNavigate();
+  const handleCardClick = jamId => {
+    navigate(`/jamdetail/${jamId}`);
+  };
   return (
-    <div className={box}>
+    <div className={box} onClick={() => handleCardClick(jam.jamId)}>
       <div className={coverImage} />
       <div className={bottomArea}>
         <p>{jam.title}</p>

--- a/client/src/Components/Category/LongJamCard.js
+++ b/client/src/Components/Category/LongJamCard.js
@@ -1,9 +1,12 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
 // import { BiCategory } from 'react-icons/bi';
 import { BsClockFill, BsPeopleFill } from 'react-icons/bs';
 import { ImLocation } from 'react-icons/im';
 // import { FaUserCircle } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
 import { palette } from '../../Styles/theme';
 import jamElapsedTime from '../userComp/JamElapsedTime';
 
@@ -18,6 +21,7 @@ const box = css`
   align-items: center;
   padding: 10px 15px;
   margin: 10px;
+  cursor: pointer;
 `;
 
 const openedJam = css`
@@ -82,8 +86,12 @@ const LongJamCard = ({ jam }) => {
   } else if (jam.completeStatus === 'TRUE') {
     isCompleteJam = true;
   }
+  const navigate = useNavigate();
+  const handleCardClick = jamId => {
+    navigate(`/jamdetail/${jamId}`);
+  };
   return (
-    <div className={box}>
+    <div className={box} onClick={() => handleCardClick(jam.jamId)}>
       <div className={coverImage} />
       <div className={info}>
         <div className={topInfo}>

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -14,6 +14,7 @@ import Select from '@mui/material/Select';
 import { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { ThemeProvider } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { palette, theme } from '../../Styles/theme';
 import getJuso from './getJuso';
 import { location } from '../../Atom/atoms';
@@ -43,6 +44,8 @@ export default function AddressDialog() {
   const [cityList, setCityList] = useState([]);
   const [guList, setGuList] = useState([]);
   const [dongList, setDongList] = useState([]);
+
+  const navigate = useNavigate();
 
   // 대한민국의 모든 특별/광역시, 도 반환
   function getCityData(code) {
@@ -102,6 +105,7 @@ export default function AddressDialog() {
 
   // dialog open/close 설정
   const handleClickOpen = () => {
+    navigate('/home');
     setOpen(true);
   };
   const handleClose = () => {

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -128,6 +128,7 @@ const SearchBar = () => {
           // value={searchText}
           placeholder="제목이나 내용으로 검색해보세요!"
           inputProps={{ 'aria-label': 'search' }}
+          onClick={() => sessionStorage.clear()}
         />
       </Search>
     </form>
@@ -175,7 +176,7 @@ const Header = () => {
   return (
     <div className={headerBox}>
       <div className={header}>
-        <Link to="/">
+        <Link to="/" onClick={() => sessionStorage.clear}>
           <img className={logo} alt="logo_jamit" src={logoImage} />
         </Link>
         <AddressDialog />

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -165,13 +165,8 @@ const LogoutArea = () => {
 };
 
 const Header = () => {
-  const [isLogin, setIsLogin] = useRecoilState(isLoginState);
+  const [isLogin] = useRecoilState(isLoginState);
   // const [isAddressClick, setIsAddressClick] = useState(false);
-  const onLoginBtnClick = () => {
-    console.log('버튼클릭');
-    setIsLogin(!isLogin);
-    console.log(isLogin);
-  };
 
   return (
     <div className={headerBox}>
@@ -180,13 +175,6 @@ const Header = () => {
           <img className={logo} alt="logo_jamit" src={logoImage} />
         </Link>
         <AddressDialog />
-        <button
-          type="button"
-          className={createJamBtn}
-          onClick={onLoginBtnClick}
-        >
-          임시로그인토글{' '}
-        </button>
         <SearchBar />
 
         {/* <LoginArea /> */}

--- a/client/src/Components/Landing/Categories.js
+++ b/client/src/Components/Landing/Categories.js
@@ -123,15 +123,10 @@ const images = [
 ];
 
 export default function Categories() {
-  const [category, setCategory] = useRecoilState(selectedCategory);
+  const [, setCategory] = useRecoilState(selectedCategory);
   const handleCategoryClick = title => {
-    console.log(title);
     setCategory(categories.find(el => el.label === title));
   };
-
-  React.useEffect(() => {
-    console.log(category);
-  }, [category]);
 
   return (
     <Container component="section" sx={{ mt: 8, mb: 4 }}>

--- a/client/src/Components/Landing/Categories.js
+++ b/client/src/Components/Landing/Categories.js
@@ -143,30 +143,30 @@ export default function Categories() {
               }}
             />
             <ImageBackdrop className="imageBackdrop" />
-            <Box
-              sx={{
-                position: 'absolute',
-                left: 0,
-                right: 0,
-                top: 0,
-                bottom: 0,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: 'common.white',
-              }}
-            >
-              <Typography
-                component="h5"
-                variant="h6"
-                color="inherit"
-                className="imageTitle"
+            <Link to="/category" style={{ color: 'white' }}>
+              <Box
+                sx={{
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  bottom: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  color: 'common.white',
+                }}
               >
-                <Link to="/category" style={{ color: 'white' }}>
+                <Typography
+                  component="h5"
+                  variant="h6"
+                  color="inherit"
+                  className="imageTitle"
+                >
                   {image.title}
-                </Link>
-              </Typography>
-            </Box>
+                </Typography>
+              </Box>
+            </Link>
           </ImageIconButton>
         ))}
       </Box>

--- a/client/src/Components/Landing/Categories.js
+++ b/client/src/Components/Landing/Categories.js
@@ -6,7 +6,10 @@ import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Container from '@mui/material/Container';
+import { useRecoilState } from 'recoil';
 import Typography from './Typography';
+import { selectedCategory } from '../../Atom/atoms';
+import categories from '../../Static/categories';
 
 const ImageBackdrop = styled('div')(({ theme }) => ({
   position: 'absolute',
@@ -120,6 +123,16 @@ const images = [
 ];
 
 export default function Categories() {
+  const [category, setCategory] = useRecoilState(selectedCategory);
+  const handleCategoryClick = title => {
+    console.log(title);
+    setCategory(categories.find(el => el.label === title));
+  };
+
+  React.useEffect(() => {
+    console.log(category);
+  }, [category]);
+
   return (
     <Container component="section" sx={{ mt: 8, mb: 4 }}>
       <Box sx={{ mt: 8, display: 'flex', flexWrap: 'wrap' }}>
@@ -129,6 +142,7 @@ export default function Categories() {
             style={{
               width: image.width,
             }}
+            onClick={() => handleCategoryClick(image.title)}
           >
             <Box
               sx={{

--- a/client/src/Components/NoData.js
+++ b/client/src/Components/NoData.js
@@ -19,12 +19,6 @@ const text1 = css`
   font-size: 24px;
   margin: 5px;
 `;
-const text2 = css`
-  word-break: keep-all;
-  text-align: center;
-  font-size: large;
-  margin: 15px;
-`;
 
 const containerHome = css`
   display: flex;
@@ -50,20 +44,11 @@ const text2Home = css`
   font-size: large;
   margin: 15px;
 `;
-export const NoSearchData = () => {
-  return (
-    <div className={container}>
-      <div className={text1}>000의</div>
-      <div className={text1}>결과를 찾을 수 없습니다.</div>
-      <div className={text2}>비슷한 검색어로 다시 검색해보세요!</div>
-    </div>
-  );
-};
 
 export const NoCategoryData = () => {
   return (
     <div className={container}>
-      <div className={text1}>현재 카테고리의 잼이 없습니다.</div>
+      <div className={text1}>해당하는 잼이 없습니다.</div>
     </div>
   );
 };

--- a/client/src/Components/Sidebar.js
+++ b/client/src/Components/Sidebar.js
@@ -52,6 +52,7 @@ const Sidebar = () => {
       categories.filter(el => el.label === e.target.innerText)[0],
     );
     navigate('/category');
+    sessionStorage.clear();
   };
 
   useEffect(() => {

--- a/client/src/Components/Sidebar.js
+++ b/client/src/Components/Sidebar.js
@@ -2,8 +2,9 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 import { palette } from '../Styles/theme';
 import { selectedCategory } from '../Atom/atoms';
 import categories from '../Static/categories';
@@ -41,14 +42,21 @@ const sidebar = css`
 `;
 
 const Sidebar = () => {
-  const [, setCurrentCategory] = useRecoilState(selectedCategory);
+  const [currentCategory, setCurrentCategory] =
+    useRecoilState(selectedCategory);
+  const navigate = useNavigate();
 
   const onCategoryClick = e => {
     console.log(e.target.innerText);
     setCurrentCategory(
       categories.filter(el => el.label === e.target.innerText)[0],
     );
+    navigate('/category');
   };
+
+  useEffect(() => {
+    console.log('sidebar에서 current category 변경: ', currentCategory);
+  }, [currentCategory]);
   return (
     <div className={sidebar}>
       <div>카테고리</div>


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 카테고리의 [내 주변]을 클릭하면 /home으로 이동하도록 수정했습니다.
- 헤더의 동네 선택 버튼 클릭시 /home으로 이동하도록 수정했습니다.
- 랜딩페이지의 카테고리 클릭 범위를 텍스트 주변 -> 배경 이미지로 수정했습니다.
- 랜딩페이지의 카테고리 클릭시 /category 페이지로 이동할 때 클릭한 카테고리의 잼 데이터를 불러오도록 수정했습니다.
- 검색어 초기화 기능을 추가해 이전의 검색어가 잼 조회에 영향이 없도록 수정했습니다.
- JamCard, LongJamCard 클릭시 해당 잼의 상세페이지로 이동하는 기능을 추가했습니다.
- 헤더의 임시로그인토글 버튼을 삭제했습니다.
- 그 외 사용하지 않는 코드들을 제거했습니다.

## 스크린샷
![Kapture 2022-12-02 at 21 43 38](https://user-images.githubusercontent.com/53070295/205295676-3b3df2ca-5e23-452e-a1ce-a471efae166d.gif)


