### PR TITLE
[client] 잼 상세 위치 지도 구현, 잼 모집, 참여와 취소 수정, 이미지 업로드 구현

### DIFF
--- a/client/src/Components/jamCreateComponent/EditButtonGroup.js
+++ b/client/src/Components/jamCreateComponent/EditButtonGroup.js
@@ -115,7 +115,7 @@ const EditButtonGroup = ({ patchData }) => {
         <button
           css={[CancleEdit, FinishEdit]}
           type="button"
-          form="makeStudy"
+          // form="makeStudy"
           onClick={handleEdit}
         >
           수정완료

--- a/client/src/Components/jamCreateComponent/KakaoMap.js
+++ b/client/src/Components/jamCreateComponent/KakaoMap.js
@@ -1,3 +1,6 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable react/jsx-no-comment-textnodes */
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 /* eslint-disable no-plusplus */
@@ -203,9 +206,12 @@ const KakaoMap = ({
                   <div className={resultNumber}>{i + 1}</div>
                   <div className={resultTextBox}>
                     {/* <h5>{item.place_name}</h5> */}
-                    <button type="button" onClick={() => handleTextInput(item)}>
+                    <div onClick={() => handleTextInput(item)}>
                       {item.place_name}
-                    </button>
+                    </div>
+                    {/* <button type="button" onClick={() => handleTextInput(item)}>
+                      {item.place_name}
+                    </button> */}
                     {item.road_address_name ? (
                       <div>
                         <span>{item.road_address_name}</span>

--- a/client/src/Components/jamCreateComponent/MapLanding.js
+++ b/client/src/Components/jamCreateComponent/MapLanding.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
@@ -82,7 +84,7 @@ function MapLanding({
         setAddress={setAddress}
       />
       {inputWindow && (
-        <form className={inputForm} onSubmit="return false;">
+        <div className={inputForm}>
           <input
             type="text"
             placeholder="키워드를 입력해주세요"
@@ -92,7 +94,7 @@ function MapLanding({
           <button type="button" onClick={handleSubmit}>
             검색
           </button>
-        </form>
+        </div>
       )}
     </div>
   );

--- a/client/src/Components/jamCreateComponent/MapLanding.js
+++ b/client/src/Components/jamCreateComponent/MapLanding.js
@@ -66,7 +66,7 @@ function MapLanding({
   const handleSubmit = e => {
     e.preventDefault();
     setKeyword(InputText);
-    setInputText('');
+    // setInputText('');
   };
 
   return (
@@ -82,13 +82,16 @@ function MapLanding({
         setAddress={setAddress}
       />
       {inputWindow && (
-        <form className={inputForm} onSubmit={handleSubmit}>
+        <form className={inputForm} onSubmit="return false;">
           <input
+            type="text"
             placeholder="키워드를 입력해주세요"
             onChange={onChange}
             value={InputText}
           />
-          <button type="submit">검색</button>
+          <button type="button" onClick={handleSubmit}>
+            검색
+          </button>
         </form>
       )}
     </div>

--- a/client/src/Components/jamCreateComponent/Uploader.js
+++ b/client/src/Components/jamCreateComponent/Uploader.js
@@ -64,36 +64,7 @@ const UploadButton = css`
 const BASE_URL = `${process.env.REACT_APP_URL}`;
 
 const Uploader = ({ image, setImage }) => {
-  // 기타 데이터와 한번에 submit 하기 위해 상위 컴포넌트로 이동후 전달
-  // const [image, setImage] = useState({
-  //   image_file: '',
-  //   previewURL: uploadImage,
-  // });
-  // const [profileFile, setProfileFile] = useState(null);
-  // const [img, setImg] = useState('');
-
   const fileInputRef = useRef(null);
-
-  // const dataURLtoFile = (dataurl, fileName) => {
-  //   const arr = dataurl.split(',');
-  //   const mime = arr[0].match(/:(.*?);/)[1];
-  //   const bstr = atob(arr[1]);
-  //   let n = bstr.length;
-  //   const u8arr = new Uint8Array(n);
-
-  //   // eslint-disable-next-line no-plusplus
-  //   while (n--) {
-  //     u8arr[n] = bstr.charCodeAt(n);
-  //   }
-
-  //   return new File([u8arr], fileName, { type: mime });
-  // };
-
-  // const getImage = async () => {
-  //   const b64data = defaultImage.current.currentSrc;
-  //   const imagefile = dataURLtoFile(b64data, 'defaultImage.jpeg');
-  //   return imagefile;
-  // };
 
   const handleClickFileInput = () => {
     fileInputRef.current.click();
@@ -101,10 +72,6 @@ const Uploader = ({ image, setImage }) => {
 
   const saveImage = async e => {
     e.preventDefault();
-    // eslint-disable-next-line no-shadow
-    // const img = e.target.files[0];
-    // console.log('img', img);
-    // setImage(e.target.files[0]);
 
     const formData = new FormData();
     formData.append('file', e.target.files[0]);
@@ -136,117 +103,6 @@ const Uploader = ({ image, setImage }) => {
     });
   };
 
-  // setImage(() => ({
-  //   image_file: e.target.files[0],
-  // }));
-  // };
-
-  // const sendImageToServer = async () => {
-  //   // if (image.image_file) {
-  //   const formData = new FormData();
-  //   formData.append('file', image.image_file);
-  //   // formData.append('upload_preset', 'mvrdnxnf');
-
-  //   for (const [key, value] of formData.entries()) {
-  //     console.log([key, value]);
-  //   }
-
-  //   // await axios.post('/이미지업로드용api', formData)
-  //   await axios
-  //     .post('/upload', formData, {
-  //       headers: {
-  //         Authorization: `Bearer ${accessToken}`,
-  //         'Content-Type': 'multipart/form-data',
-  //       },
-  //     })
-  //     .then(res => {
-  //       console.log(res.data);
-  //       alert('파일이 성공적으로 등록되었습니다!');
-  //       // res.blob();
-  //     });
-  // }
-
-  // useEffect(() => {
-  //   // 구독 취소로 컴포넌트가 언마운트되면 생성되었던 기존 URL을 폐기
-  //   return () => {
-  //     URL.revokeObjectURL(image.previewURL);
-  //   };
-  // }, []);
-
-  // const handleClickFileInput = () => {
-  //   fileInputRef.current.click();
-  // };
-
-  // const saveImage = e => {
-  //   e.preventDefault();
-  //   // 타겟팅한 파일 값 확인
-  //   // console.log(e.target.files[0]);
-
-  //   if (e.target.files[0]) {
-  //     // 새로운 이미지를 올리면 revokeObjectURL()을 통해 생성한 기존 URL을 먼저 폐기하고
-  //     URL.revokeObjectURL(image.previewURL);
-  //     // createObjectURL()을 통해 새로 올린 파일에 대한 URL을 생성하여
-  //     const previewURL = URL.createObjectURL(e.target.files[0]);
-  //     console.log(e.target.files[0]);
-  //     // 현재 다루는 이미지에 대한 상태를 set으로 업데이트
-  //     setImage(() => ({
-  //       image_file: e.target.files[0],
-  //       previewURL,
-  //     }));
-  //   }
-  // };
-
-  // const deleteImage = () => {
-  //   // 생성되었던 기존 URL 폐기
-  //   URL.revokeObjectURL(image.previewURL);
-  //   setImage({
-  //     image_file: '',
-  //     previewURL: null,
-  //   });
-  // };
-
-  // const sendImageToServer = async () => {
-  //   if (image.image_file) {
-  //     const formData = new FormData();
-  //     formData.append('file', image.image_file);
-  //     // formData.append('upload_preset', 'mvrdnxnf');
-
-  //     // await axios.post('/이미지업로드용api', formData)
-  //     await axios
-  //       .post('/upload', formData, {
-  //         headers: {
-  //           Authorization: `Bearer ${accessToken}`,
-  //           'Content-Type': 'multipart/form-data',
-  //         },
-  //       })
-  //       .then(res => {
-  //         console.log(res);
-  //         alert('파일이 성공적으로 등록되었습니다!');
-  //         res.blob();
-  //       });
-
-  //     // const res = await fetch(`/upload`, {
-  //     //   method: 'POST',
-  //     //   body: formData,
-  //     // });
-
-  //     // // 이미지 업로드 이후이므로 이미지 상태를 다시 초기화
-  //     // setImage({
-  //     //   image_file: '',
-  //     //   // previewURL: null,
-  //     //   // previewURL: image.previewURL,
-  //     //   previewURL: res,
-  //     // });
-  //     // console.log(res.url);
-  //     // return res.json();
-  //     // return res.blob();
-  //   }
-  //   alert('사진을 등록하세요!');
-  // };
-
-  // console.log('image: ', image);
-  // console.log('profileFile: ', profileFile);
-
   return (
     <div css={Container}>
       <label htmlFor="inputFile">
@@ -266,8 +122,6 @@ const Uploader = ({ image, setImage }) => {
             type="file"
             accept="image/*"
             onChange={saveImage}
-            // 클릭할 때 마다 file input의 value를 초기화 하지 않으면 버그가 발생할 수 있음
-            // onClick={e => e.target.value === null}
             ref={fileInputRef}
             onClick={handleClickFileInput}
             hidden
@@ -275,12 +129,10 @@ const Uploader = ({ image, setImage }) => {
           />
         </div>
       </label>
-      {/* {image.previewURL && ( */}
       <div css={UploadButton}>
         <Button
           type="primary"
           variant="contained"
-          // onClick={() => inputRef.click()}
           onClick={handleClickFileInput}
         >
           미리보기
@@ -288,9 +140,6 @@ const Uploader = ({ image, setImage }) => {
         <Button color="error" variant="contained" onClick={deleteImage}>
           삭제
         </Button>
-        {/* <Button color="success" variant="contained" onClick={sendImageToServer}>
-          업로드
-        </Button> */}
       </div>
     </div>
   );

--- a/client/src/Components/jamCreateComponent/Uploader.js
+++ b/client/src/Components/jamCreateComponent/Uploader.js
@@ -129,6 +129,13 @@ const Uploader = ({ image, setImage }) => {
       });
   };
 
+  const deleteImage = () => {
+    setImage({
+      image_file: '',
+      previewURL: null,
+    });
+  };
+
   // setImage(() => ({
   //   image_file: e.target.files[0],
   // }));
@@ -237,7 +244,7 @@ const Uploader = ({ image, setImage }) => {
   //   alert('사진을 등록하세요!');
   // };
 
-  console.log('image: ', image);
+  // console.log('image: ', image);
   // console.log('profileFile: ', profileFile);
 
   return (
@@ -278,9 +285,9 @@ const Uploader = ({ image, setImage }) => {
         >
           미리보기
         </Button>
-        {/* <Button color="error" variant="contained" onClick={deleteImage}>
-            삭제
-          </Button> */}
+        <Button color="error" variant="contained" onClick={deleteImage}>
+          삭제
+        </Button>
         {/* <Button color="success" variant="contained" onClick={sendImageToServer}>
           업로드
         </Button> */}

--- a/client/src/Components/jamCreateComponent/Uploader.js
+++ b/client/src/Components/jamCreateComponent/Uploader.js
@@ -2,9 +2,9 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable consistent-return */
 import { css } from '@emotion/react';
-import { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Button } from '@mui/material';
-// import axios from 'axios';
+import axios from 'axios';
 import { BsPlusCircle } from 'react-icons/bs';
 import { palette } from '../../Styles/theme';
 
@@ -61,94 +61,185 @@ const UploadButton = css`
   /* margin: 5px; */
 `;
 
+const BASE_URL = `${process.env.REACT_APP_URL}`;
+
 const Uploader = ({ image, setImage }) => {
   // 기타 데이터와 한번에 submit 하기 위해 상위 컴포넌트로 이동후 전달
   // const [image, setImage] = useState({
   //   image_file: '',
   //   previewURL: uploadImage,
   // });
+  // const [profileFile, setProfileFile] = useState(null);
+  // const [img, setImg] = useState('');
 
   const fileInputRef = useRef(null);
 
-  useEffect(() => {
-    // 구독 취소로 컴포넌트가 언마운트되면 생성되었던 기존 URL을 폐기
-    return () => {
-      URL.revokeObjectURL(image.previewURL);
-    };
-  }, []);
+  // const dataURLtoFile = (dataurl, fileName) => {
+  //   const arr = dataurl.split(',');
+  //   const mime = arr[0].match(/:(.*?);/)[1];
+  //   const bstr = atob(arr[1]);
+  //   let n = bstr.length;
+  //   const u8arr = new Uint8Array(n);
+
+  //   // eslint-disable-next-line no-plusplus
+  //   while (n--) {
+  //     u8arr[n] = bstr.charCodeAt(n);
+  //   }
+
+  //   return new File([u8arr], fileName, { type: mime });
+  // };
+
+  // const getImage = async () => {
+  //   const b64data = defaultImage.current.currentSrc;
+  //   const imagefile = dataURLtoFile(b64data, 'defaultImage.jpeg');
+  //   return imagefile;
+  // };
 
   const handleClickFileInput = () => {
     fileInputRef.current.click();
   };
 
-  const saveImage = e => {
+  const saveImage = async e => {
     e.preventDefault();
-    // 타겟팅한 파일 값 확인
-    // console.log(e.target.files[0]);
+    // eslint-disable-next-line no-shadow
+    // const img = e.target.files[0];
+    // console.log('img', img);
+    // setImage(e.target.files[0]);
 
-    if (e.target.files[0]) {
-      // 새로운 이미지를 올리면 revokeObjectURL()을 통해 생성한 기존 URL을 먼저 폐기하고
-      URL.revokeObjectURL(image.previewURL);
-      // createObjectURL()을 통해 새로 올린 파일에 대한 URL을 생성하여
-      const previewURL = URL.createObjectURL(e.target.files[0]);
-      console.log(e.target.files[0]);
-      // 현재 다루는 이미지에 대한 상태를 set으로 업데이트
-      setImage(() => ({
-        image_file: e.target.files[0],
-        previewURL,
-      }));
+    const formData = new FormData();
+    formData.append('file', e.target.files[0]);
+
+    for (const [key, value] of formData.entries()) {
+      console.log([key, value]);
     }
-  };
 
-  const deleteImage = () => {
-    // 생성되었던 기존 URL 폐기
-    URL.revokeObjectURL(image.previewURL);
-    setImage({
-      image_file: '',
-      previewURL: null,
-    });
-  };
-
-  const sendImageToServer = async () => {
-    if (image.image_file) {
-      const formData = new FormData();
-      formData.append('file', image.image_file);
-      formData.append('upload_preset', 'mvrdnxnf');
-      // await axios.post('/이미지업로드용api', formData)
-      // await axios
-      //   .post('https://api.imgur.com/3/image', formData, {
-      //     headers: {
-      //       Authorization: 'Client-ID a776c4679ff9954',
-      //       'Content-Type': 'multipart/form-data',
-      //     },
-      //   })
-      //   .then(res => {
-      //     console.log(res);
-      //     alert('파일이 성공적으로 등록되었습니다!');
-      //     // res.blob();
-      //   });
-      const res = await fetch(
-        `https://api.cloudinary.com/v1_1/dwe5nou7y/image/upload`,
-        {
-          method: 'POST',
-          body: formData,
+    // eslint-disable-next-line no-undef
+    await axios
+      .post(`${BASE_URL}/upload`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
         },
-      );
-      // 이미지 업로드 이후이므로 이미지 상태를 다시 초기화
-      setImage({
-        image_file: '',
-        // previewURL: null,
-        // previewURL: image.previewURL,
-        previewURL: res,
+      })
+      .then(res => {
+        console.log(res.data);
+        setImage({ previewURL: res.data });
+      })
+      .catch(err => {
+        console.log(err.Error);
       });
-      console.log(res.url);
-      return res.json();
-      // return res.blob();
-    }
-    alert('사진을 등록하세요!');
   };
+
+  // setImage(() => ({
+  //   image_file: e.target.files[0],
+  // }));
+  // };
+
+  // const sendImageToServer = async () => {
+  //   // if (image.image_file) {
+  //   const formData = new FormData();
+  //   formData.append('file', image.image_file);
+  //   // formData.append('upload_preset', 'mvrdnxnf');
+
+  //   for (const [key, value] of formData.entries()) {
+  //     console.log([key, value]);
+  //   }
+
+  //   // await axios.post('/이미지업로드용api', formData)
+  //   await axios
+  //     .post('/upload', formData, {
+  //       headers: {
+  //         Authorization: `Bearer ${accessToken}`,
+  //         'Content-Type': 'multipart/form-data',
+  //       },
+  //     })
+  //     .then(res => {
+  //       console.log(res.data);
+  //       alert('파일이 성공적으로 등록되었습니다!');
+  //       // res.blob();
+  //     });
+  // }
+
+  // useEffect(() => {
+  //   // 구독 취소로 컴포넌트가 언마운트되면 생성되었던 기존 URL을 폐기
+  //   return () => {
+  //     URL.revokeObjectURL(image.previewURL);
+  //   };
+  // }, []);
+
+  // const handleClickFileInput = () => {
+  //   fileInputRef.current.click();
+  // };
+
+  // const saveImage = e => {
+  //   e.preventDefault();
+  //   // 타겟팅한 파일 값 확인
+  //   // console.log(e.target.files[0]);
+
+  //   if (e.target.files[0]) {
+  //     // 새로운 이미지를 올리면 revokeObjectURL()을 통해 생성한 기존 URL을 먼저 폐기하고
+  //     URL.revokeObjectURL(image.previewURL);
+  //     // createObjectURL()을 통해 새로 올린 파일에 대한 URL을 생성하여
+  //     const previewURL = URL.createObjectURL(e.target.files[0]);
+  //     console.log(e.target.files[0]);
+  //     // 현재 다루는 이미지에 대한 상태를 set으로 업데이트
+  //     setImage(() => ({
+  //       image_file: e.target.files[0],
+  //       previewURL,
+  //     }));
+  //   }
+  // };
+
+  // const deleteImage = () => {
+  //   // 생성되었던 기존 URL 폐기
+  //   URL.revokeObjectURL(image.previewURL);
+  //   setImage({
+  //     image_file: '',
+  //     previewURL: null,
+  //   });
+  // };
+
+  // const sendImageToServer = async () => {
+  //   if (image.image_file) {
+  //     const formData = new FormData();
+  //     formData.append('file', image.image_file);
+  //     // formData.append('upload_preset', 'mvrdnxnf');
+
+  //     // await axios.post('/이미지업로드용api', formData)
+  //     await axios
+  //       .post('/upload', formData, {
+  //         headers: {
+  //           Authorization: `Bearer ${accessToken}`,
+  //           'Content-Type': 'multipart/form-data',
+  //         },
+  //       })
+  //       .then(res => {
+  //         console.log(res);
+  //         alert('파일이 성공적으로 등록되었습니다!');
+  //         res.blob();
+  //       });
+
+  //     // const res = await fetch(`/upload`, {
+  //     //   method: 'POST',
+  //     //   body: formData,
+  //     // });
+
+  //     // // 이미지 업로드 이후이므로 이미지 상태를 다시 초기화
+  //     // setImage({
+  //     //   image_file: '',
+  //     //   // previewURL: null,
+  //     //   // previewURL: image.previewURL,
+  //     //   previewURL: res,
+  //     // });
+  //     // console.log(res.url);
+  //     // return res.json();
+  //     // return res.blob();
+  //   }
+  //   alert('사진을 등록하세요!');
+  // };
 
   console.log('image: ', image);
+  // console.log('profileFile: ', profileFile);
+
   return (
     <div css={Container}>
       <label htmlFor="inputFile">
@@ -171,34 +262,29 @@ const Uploader = ({ image, setImage }) => {
             // 클릭할 때 마다 file input의 value를 초기화 하지 않으면 버그가 발생할 수 있음
             // onClick={e => e.target.value === null}
             ref={fileInputRef}
-            // onClick={handleClickFileInput}
+            onClick={handleClickFileInput}
             hidden
             style={{ display: 'none' }}
           />
         </div>
       </label>
-      {image.previewURL && (
-        <div css={UploadButton}>
-          <Button
-            type="primary"
-            variant="contained"
-            // onClick={() => inputRef.click()}
-            onClick={handleClickFileInput}
-          >
-            미리보기
-          </Button>
-          <Button color="error" variant="contained" onClick={deleteImage}>
+      {/* {image.previewURL && ( */}
+      <div css={UploadButton}>
+        <Button
+          type="primary"
+          variant="contained"
+          // onClick={() => inputRef.click()}
+          onClick={handleClickFileInput}
+        >
+          미리보기
+        </Button>
+        {/* <Button color="error" variant="contained" onClick={deleteImage}>
             삭제
-          </Button>
-          <Button
-            color="success"
-            variant="contained"
-            onClick={sendImageToServer}
-          >
-            업로드
-          </Button>
-        </div>
-      )}
+          </Button> */}
+        {/* <Button color="success" variant="contained" onClick={sendImageToServer}>
+          업로드
+        </Button> */}
+      </div>
     </div>
   );
 };

--- a/client/src/Components/jamDetailComponent/JamCarousel.js
+++ b/client/src/Components/jamDetailComponent/JamCarousel.js
@@ -42,7 +42,7 @@ const SliderStyle = styled(Slider)`
   }
   .slick-slide img {
     width: 100%;
-    /* height: 100%; */
+    height: 100%;
     object-fit: cover;
   }
   .slick-dots {
@@ -124,7 +124,7 @@ const SlickArrowRight = ({ currentSlide, slideCount, ...props }) => (
 );
 
 const JamCarousel = ({ jamData }) => {
-  const { content } = jamData;
+  const { content, image } = jamData;
 
   const settings = {
     dots: true,
@@ -145,10 +145,7 @@ const JamCarousel = ({ jamData }) => {
           <span>{content}</span>
         </div>
         <div>
-          <img
-            src="https://cdn.pixabay.com/photo/2022/10/21/08/39/cat-7536508__340.jpg"
-            alt="cat"
-          />
+          <img src={image} alt="studyimage" />
         </div>
         {/* <div>
           <img

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -8,11 +8,13 @@ import { ImLocation } from 'react-icons/im';
 import { FaUserCircle } from 'react-icons/fa';
 import { ThemeProvider } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import { palette } from '../../Styles/theme';
 import JamCarousel from './JamCarousel';
 import jamElapsedTime from '../userComp/JamElapsedTime';
 import { categories } from '../jamCreateComponent/StudyInputField';
 import JamLocationMap from './JamLocationMap';
+import { loginUserInfoState } from '../../Atom/atoms';
 
 const Container = css`
   margin: 0 auto;
@@ -105,12 +107,12 @@ const EditButton = css`
   border-radius: 3px;
 `;
 
-const JamInfo = ({ host, loginUser, setIsEdit, jamData }) => {
+const JamInfo = ({ setIsEdit, jamData }) => {
   // const [filteredCategory, setFilteredCategory] = useState([])
+  const [currentUser] = useRecoilState(loginUserInfoState);
 
   const navigate = useNavigate();
   const { id } = useParams();
-  // console.log('id: ', id);
 
   const {
     title,
@@ -136,7 +138,7 @@ const JamInfo = ({ host, loginUser, setIsEdit, jamData }) => {
       <div css={HeaderContainer}>
         <div css={TitleContainer}>
           <h2 css={Title}>{title}</h2>
-          {host === loginUser && (
+          {nickname === currentUser.nickname && (
             <button css={EditButton} type="button" onClick={handleIsEdit}>
               수정
             </button>

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -12,6 +12,7 @@ import { palette } from '../../Styles/theme';
 import JamCarousel from './JamCarousel';
 import jamElapsedTime from '../userComp/JamElapsedTime';
 import { categories } from '../jamCreateComponent/StudyInputField';
+import JamLocationMap from './JamLocationMap';
 
 const Container = css`
   margin: 0 auto;
@@ -93,7 +94,6 @@ const LocationMap = css`
   display: flex;
   justify-content: center;
   align-items: center;
-  /* background-color: #fff; */
   border: 1px solid ${palette.border};
 `;
 
@@ -179,7 +179,7 @@ const JamInfo = ({ host, loginUser, setIsEdit, jamData }) => {
         </div>
         <ThemeProvider theme={palette}>
           <div css={LocationMap}>
-            <span>지도 들어갈 곳</span>
+            {jamData && <JamLocationMap jamData={jamData} />}
           </div>
         </ThemeProvider>
       </div>

--- a/client/src/Components/jamDetailComponent/JamLocationMap.js
+++ b/client/src/Components/jamDetailComponent/JamLocationMap.js
@@ -1,7 +1,43 @@
-import React from 'react';
+/* eslint-disable no-plusplus */
+/* eslint-disable react/prop-types */
+import { useEffect } from 'react';
 
-const JamLocationMap = () => {
-  return <div>JamLocationMap</div>;
+const { kakao } = window;
+
+const JamLocationMap = ({ jamData }) => {
+  // 좌표로 주소 얻기
+  function getMap() {
+    const container = document.getElementById('map'); // 지도를 표시할 div
+    const options = {
+      center: new kakao.maps.LatLng(jamData.latitude, jamData.longitude), // 지도의 중심좌표
+      level: 3, // 지도 확대 레벨
+    };
+
+    const map = new kakao.maps.Map(container, options);
+    return map;
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line no-unused-expressions
+    jamData && getMap();
+  }, [jamData]);
+
+  // console.log(jamLocation);
+  // console.log('jamData: ', jamData);
+  console.log('latitude: ', jamData.latitude);
+  console.log('longitude: ', jamData.longitude);
+
+  return (
+    jamData && (
+      <div
+        id="map"
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+      />
+    )
+  );
 };
 
 export default JamLocationMap;

--- a/client/src/Components/jamDetailComponent/JamLocationMap.js
+++ b/client/src/Components/jamDetailComponent/JamLocationMap.js
@@ -17,9 +17,47 @@ const JamLocationMap = ({ jamData }) => {
     return map;
   }
 
+  const MapPin = () => {
+    // 마커를 표시할 위치와 내용을 가지고 있는 객체 배열입니다
+    const positions = [
+      {
+        content: `<div>${jamData.location}</div>`,
+        latlng: new kakao.maps.LatLng(jamData.latitude, jamData.longitude),
+      },
+    ];
+    const map = getMap();
+    for (let i = 0; i < positions.length; i++) {
+      // 마커를 생성합니다
+      const marker = new kakao.maps.Marker({
+        map, // 마커를 표시할 지도
+        position: positions[i].latlng, // 마커의 위치
+      });
+
+      // 마커에 표시할 인포윈도우를 생성합니다
+      const infowindow = new kakao.maps.InfoWindow({
+        content: positions[i].content, // 인포윈도우에 표시할 내용
+      });
+
+      // 마커에 이벤트를 등록하는 함수 만들고 즉시 호출하여 클로저를 만듭니다
+      // 클로저를 만들어 주지 않으면 마지막 마커에만 이벤트가 등록됩니다
+      (function (point, window) {
+        // 마커에 mouseover 이벤트를 등록하고 마우스 오버 시 인포윈도우를 표시합니다
+        kakao.maps.event.addListener(point, 'mouseover', function () {
+          window.open(map, point);
+        });
+
+        // 마커에 mouseout 이벤트를 등록하고 마우스 아웃 시 인포윈도우를 닫습니다
+        kakao.maps.event.addListener(point, 'mouseout', function () {
+          window.close();
+        });
+      })(marker, infowindow);
+    }
+  };
+
   useEffect(() => {
     // eslint-disable-next-line no-unused-expressions
-    jamData && getMap();
+    jamData && MapPin();
+    // jamData && getMap();
   }, [jamData]);
 
   // console.log(jamLocation);

--- a/client/src/Components/jamDetailComponent/JamLocationMap.js
+++ b/client/src/Components/jamDetailComponent/JamLocationMap.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const JamLocationMap = () => {
+  return <div>JamLocationMap</div>;
+};
+
+export default JamLocationMap;

--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import { BiCategory } from 'react-icons/bi';
 import { BsClockFill, BsPeopleFill } from 'react-icons/bs';
@@ -8,10 +8,12 @@ import { ImLocation } from 'react-icons/im';
 import { FaUserCircle } from 'react-icons/fa';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
+import { useRecoilState } from 'recoil';
 import RecruitState from './RecruitState';
 import jamElapsedTime from '../userComp/JamElapsedTime';
 import { categories } from '../jamCreateComponent/StudyInputField';
 import { getCookie } from '../SignComp/Cookie';
+import { loginUserInfoState } from '../../Atom/atoms';
 
 const JamSideContainer = css`
   width: 220px;
@@ -118,6 +120,8 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
   const [isRegisterd, setIsRegistered] = useState(false);
   // eslint-disable-next-line no-unused-vars
   const [isClosed, setIsClosed] = useState(false);
+  const [jamCompleteStatus, setJamCompleteStatus] = useState('FALSE');
+  const [user] = useRecoilState(loginUserInfoState);
 
   const navigate = useNavigate();
   const { id } = useParams();
@@ -132,7 +136,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
     capacity,
     createdAt,
     category,
-    completeStatus,
+    // completeStatus,
     openChatLink,
     // participantList,
   } = jamData;
@@ -164,7 +168,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
         .then(res => {
           console.log('res.status: ', res.status);
           if (res.status === 200) {
-            setIsClosed(true);
+            setJamCompleteStatus('TRUE');
           }
         })
         .catch(error => {
@@ -173,7 +177,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
     }
   };
 
-  const handleOpen = async () => {
+  const handleCancelClose = async () => {
     // eslint-disable-next-line no-restricted-globals, no-alert
     const confirmData = confirm('모집완료를 취소하시겠습니까?');
 
@@ -193,7 +197,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
         .then(res => {
           console.log('res.status: ', res.status);
           if (res.status === 200) {
-            setIsClosed(false);
+            setJamCompleteStatus('FALSE');
           }
         })
         .catch(error => {
@@ -261,7 +265,12 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
     }
   };
 
+  // useEffect(() => {
+
+  // }, [jamData.completeStatus]);
+
   console.log(jamData);
+  console.log('user.nickname: ', user.nickname);
 
   return (
     <div css={JamSideContainer}>
@@ -271,7 +280,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
             <FaUserCircle />
             <span>{nickname}</span>
           </div>
-          {completeStatus === 'FALSE' ? (
+          {jamCompleteStatus === 'FALSE' ? (
             <RecruitState state="open" variant="colorJamOpen">
               모집중
             </RecruitState>
@@ -346,7 +355,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
         </div>
       ) : (
         <div css={ButtonContainer}>
-          {completeStatus === 'FALSE' ? (
+          {jamCompleteStatus === 'FALSE' ? (
             <button
               type="button"
               css={[RegisterButton, CloseJamButton]}
@@ -358,7 +367,7 @@ const JamSideBar = ({ host, loginUser, jamData }) => {
             <button
               type="button"
               css={[RegisterButton, CloseJamButton, CancleButton]}
-              onClick={handleOpen}
+              onClick={handleCancelClose}
             >
               모집완료 취소
             </button>

--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 import React from 'react';
@@ -78,7 +79,19 @@ const EtcInfo = css`
   }
 `;
 
-const AvatarContainer = css``;
+const AvatarContainer = css`
+  width: 100%;
+  height: fit-content;
+  img {
+    width: 30px;
+    height: 30px;
+    border-radius: 100px;
+  }
+  /* .imgContainer {
+    display: flex;
+    justify-content: flex;
+  } */
+`;
 
 const ButtonContainer = css`
   width: 100%;
@@ -290,26 +303,6 @@ const JamSideBar = ({
     }
   };
 
-  console.log(jamData);
-  // console.log('completeStatus: ', completeStatus);
-  // console.log('isJoin: ', isJoin);
-  // console.log('isJoiner(currentUser): ', isJoiner(currentUser));
-  // console.log('isComplete: ', isComplete);
-  console.log('currentUser: ', currentUser);
-  // console.log('participantList: ', jamData.participantList);
-  // console.log('currentUser.nickname: ', currentUser.nickname);
-  // console.log('isJoiner: ', isJoiner(currentUser)); // 문제 지점
-  // console.log('isJoiner(currentUser): ', isJoiner(currentUser));
-  console.log('isJoiner: ', isJoiner);
-  console.log('joiner: ', joiner);
-  // console.log('확인: ', isJoiner !== currentUser.nickname);
-  // console.log(
-  //   '확인',
-  //   jamData.participantList &&
-  //     participantList.filter(el => el.nickname === currentUser.nickname)[0]
-  //       .nickname,
-  // );
-
   return (
     <div css={JamSideContainer}>
       <div css={Header}>
@@ -355,6 +348,14 @@ const JamSideBar = ({
       {(isJoiner || nickname === currentUser.nickname) && (
         <>
           <div css={AvatarContainer}>
+            {jamData &&
+              jamData.participantList.map(el => {
+                return (
+                  <div key={el.memberId} className="imgContainer">
+                    <img src={el.image} alt={el.nickname} />
+                  </div>
+                );
+              })}
             <FaUserCircle size={25} />
             <FaUserCircle size={25} />
             <FaUserCircle size={25} />
@@ -379,10 +380,6 @@ const JamSideBar = ({
       {/* 스터디 개설 유저가 로그인 유저와 같지 않으면 참여 부분, 같으면 모집 부분 렌더 */}
       {nickname !== currentUser.nickname ? (
         <div css={ButtonContainer}>
-          {/* { 로그인 유저가 participantList에 있는지로 수정 예정 ( */}
-          {/* {isJoiner(currentUser)} */}
-          {/* {isJoiner(currentUser) !== currentUser.nickname ? ( */}
-          {/* {!isJoiner(currentUser) ? ( */}
           {!isJoiner ? (
             <button type="button" css={RegisterButton} onClick={handleJoin}>
               참여하기

--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React from 'react';
 import { css } from '@emotion/react';
 import { BiCategory } from 'react-icons/bi';
 import { BsClockFill, BsPeopleFill } from 'react-icons/bs';
@@ -117,10 +117,16 @@ const CancleButton = css`
 `;
 
 // eslint-disable-next-line no-unused-vars
-const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
+const JamSideBar = ({
+  jamData,
+  isComplete,
+  setIsComplete,
+  joiner,
+  setJoiner,
+}) => {
   // const [isJoin, setIsJoin] = useState(false);
   // eslint-disable-next-line no-unused-vars
-  const [isJoin, setIsJoin] = useState(false);
+  // const [isJoin, setIsJoin] = useState(false);
   const [currentUser] = useRecoilState(loginUserInfoState);
 
   const navigate = useNavigate();
@@ -138,7 +144,7 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
     category,
     // completeStatus,
     openChatLink,
-    participantList,
+    // participantList,
   } = jamData;
 
   const filteredCategory = categories.filter(el => el.value === category)[0];
@@ -146,13 +152,16 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
   // 로그인 유저가 잼에 참여한 리스트에 있는지 확인
   // 리턴값 true => 참여한 상태 => 참여취소 버튼 렌더
   // 리턴값 false => 미참여 상태 => 참여하기 버튼 렌더
-  const isJoiner = user => {
-    // eslint-disable-next-line no-unused-expressions
-    return (
-      jamData.participantList &&
-      participantList.filter(el => el.nickname === user.nickname).length === 1
-    );
-  };
+  // const isJoiner = user => {
+  //   // eslint-disable-next-line no-unused-expressions
+  //   return (
+  //     joiner && joiner.filter(el => el.nickname === user.nickname).length === 1
+  //   );
+  // };
+
+  const isJoiner =
+    joiner &&
+    joiner.filter(el => el.nickname === currentUser.nickname).length === 1;
 
   const handleClose = async () => {
     // eslint-disable-next-line no-restricted-globals
@@ -241,7 +250,7 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
       .then(res => {
         console.log('res.status: ', res.status);
         if (res.status === 200) {
-          setIsJoin(true);
+          setJoiner([...joiner, currentUser]);
         }
       })
       .catch(error => {
@@ -269,7 +278,10 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
         .then(res => {
           console.log('res.status: ', res.status);
           if (res.status === 200) {
-            setIsJoin(false);
+            // setJoiner(false);
+            setJoiner(
+              joiner.filter(el => el.nickname !== currentUser.nickname),
+            );
           }
         })
         .catch(error => {
@@ -283,11 +295,13 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
   // console.log('isJoin: ', isJoin);
   // console.log('isJoiner(currentUser): ', isJoiner(currentUser));
   // console.log('isComplete: ', isComplete);
-  // console.log('currentUser: ', currentUser);
+  console.log('currentUser: ', currentUser);
   // console.log('participantList: ', jamData.participantList);
   // console.log('currentUser.nickname: ', currentUser.nickname);
   // console.log('isJoiner: ', isJoiner(currentUser)); // 문제 지점
   // console.log('isJoiner(currentUser): ', isJoiner(currentUser));
+  console.log('isJoiner: ', isJoiner);
+  console.log('joiner: ', joiner);
   // console.log('확인: ', isJoiner !== currentUser.nickname);
   // console.log(
   //   '확인',
@@ -337,7 +351,8 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
         </div>
       </div>
       {/* 참여했거나 스터디 개설자와 로그인유저가 같으면 렌더  */}
-      {(isJoiner(currentUser) || nickname === currentUser.nickname) && (
+      {/* {(isJoiner(currentUser) || nickname === currentUser.nickname) && ( */}
+      {(isJoiner || nickname === currentUser.nickname) && (
         <>
           <div css={AvatarContainer}>
             <FaUserCircle size={25} />
@@ -367,7 +382,8 @@ const JamSideBar = ({ jamData, isComplete, setIsComplete }) => {
           {/* { 로그인 유저가 participantList에 있는지로 수정 예정 ( */}
           {/* {isJoiner(currentUser)} */}
           {/* {isJoiner(currentUser) !== currentUser.nickname ? ( */}
-          {!isJoiner(currentUser) ? (
+          {/* {!isJoiner(currentUser) ? ( */}
+          {!isJoiner ? (
             <button type="button" css={RegisterButton} onClick={handleJoin}>
               참여하기
             </button>

--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -82,6 +82,7 @@ const EtcInfo = css`
 const AvatarContainer = css`
   width: 100%;
   height: fit-content;
+  display: flex;
   img {
     width: 30px;
     height: 30px;
@@ -352,19 +353,10 @@ const JamSideBar = ({
               jamData.participantList.map(el => {
                 return (
                   <div key={el.memberId} className="imgContainer">
-                    <img src={el.image} alt={el.nickname} />
+                    <img src={el.profileImage} alt={el.nickname} />
                   </div>
                 );
               })}
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
-            <FaUserCircle size={25} />
           </div>
           <div>
             <span>채팅채널</span>

--- a/client/src/Components/userComp/UserTitle.js
+++ b/client/src/Components/userComp/UserTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRecoilState } from 'recoil';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/css';
-// import { Avatar } from '@mui/material/';
+import { Avatar } from '@mui/material/';
 import { palette } from '../../Styles/theme';
 import { loginUserInfoState, myPageInfoState } from '../../Atom/atoms';
 import GiveJam from './GiveJam';
@@ -62,15 +62,16 @@ const UserTitle = () => {
   const [pageUser] = useRecoilState(myPageInfoState);
   const [user] = useRecoilState(loginUserInfoState);
 
+  console.log('user', user);
+
   return (
     <div className={userTitle}>
       <div className={userTitleContainer}>
-        {/* <Avatar
-          sx={{ width: 96, height: 96 }}
-          alt="Jaehoon"
-          src={pageUser.img}
-        /> */}
-        <img src={pageUser.img} alt="userimage" />
+        {!user.img ? (
+          <Avatar sx={{ width: 96, height: 96 }} alt="Jaehoon" src={user.img} />
+        ) : (
+          <img src={user.img} alt="userimage" />
+        )}
         <div className="userTitleInfo">
           <div>{pageUser.nickname}</div>
           <div className="userTitleJam">

--- a/client/src/Components/userComp/UserTitle.js
+++ b/client/src/Components/userComp/UserTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRecoilState } from 'recoil';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/css';
-import { Avatar } from '@mui/material/';
+// import { Avatar } from '@mui/material/';
 import { palette } from '../../Styles/theme';
 import { loginUserInfoState, myPageInfoState } from '../../Atom/atoms';
 import GiveJam from './GiveJam';
@@ -35,7 +35,8 @@ const userTitleContainer = css`
     font-size: 18px;
   }
   img {
-    width: 18px;
+    width: 100px;
+    border-radius: 100px;
     padding-bottom: 1px;
   }
 `;
@@ -64,11 +65,12 @@ const UserTitle = () => {
   return (
     <div className={userTitle}>
       <div className={userTitleContainer}>
-        <Avatar
+        {/* <Avatar
           sx={{ width: 96, height: 96 }}
           alt="Jaehoon"
           src={pageUser.img}
-        />
+        /> */}
+        <img src={pageUser.img} alt="userimage" />
         <div className="userTitleInfo">
           <div>{pageUser.nickname}</div>
           <div className="userTitleJam">

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -84,15 +84,23 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
   const nextId = useRef(0);
 
   const [jamData, setJamData] = useState([]);
+  const [isComplete, setIsComplete] = useState(); // 추가
 
   const { id } = useParams();
 
   // eslint-disable-next-line no-shadow
   const getJamData = async () => {
     // eslint-disable-next-line no-return-await
-    await axios.get(`/jams/${id}`).then(res => {
-      setJamData({ ...res.data });
-    });
+    await axios
+      .get(`/jams/${id}`)
+      .then(res => {
+        // console.log('res.data: ', res.data);
+        setJamData({ ...res.data });
+        setIsComplete({ ...res.data }.completeStatus); // 추가
+      })
+      .catch(error => {
+        console.log(error.message);
+      });
   };
 
   useEffect(() => {
@@ -178,7 +186,11 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
             </div>
           </div>
         </div>
-        <JamSideBar host={host} loginUser={loginUser} jamData={jamData} />
+        <JamSideBar
+          jamData={jamData}
+          isComplete={isComplete} // 추가
+          setIsComplete={setIsComplete} // 추가
+        />
       </main>
     </div>
   );

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -84,7 +84,8 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
   const nextId = useRef(0);
 
   const [jamData, setJamData] = useState([]);
-  const [isComplete, setIsComplete] = useState(); // 추가
+  const [isComplete, setIsComplete] = useState('');
+  const [joiner, setJoiner] = useState([]);
 
   const { id } = useParams();
 
@@ -96,7 +97,8 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
       .then(res => {
         // console.log('res.data: ', res.data);
         setJamData({ ...res.data });
-        setIsComplete({ ...res.data }.completeStatus); // 추가
+        setIsComplete({ ...res.data }.completeStatus);
+        setJoiner({ ...res.data }.participantList);
       })
       .catch(error => {
         console.log(error.message);
@@ -154,6 +156,8 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
   //   setComments(comments.filter(comment => !comment.responseTo));
   // }, [comments]);
 
+  console.log('joiner: ', joiner);
+
   return (
     <div css={MergeContainer}>
       <Sidebar />
@@ -188,8 +192,10 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
         </div>
         <JamSideBar
           jamData={jamData}
-          isComplete={isComplete} // 추가
-          setIsComplete={setIsComplete} // 추가
+          isComplete={isComplete}
+          setIsComplete={setIsComplete}
+          joiner={joiner}
+          setJoiner={setJoiner}
         />
       </main>
     </div>

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -335,12 +335,6 @@ const JamMake = ({ isEdit }) => {
     });
   }, []);
 
-  // console.log('jamDataaaa: ', jamData);
-
-  // setLocationText(jamData.location);
-  // setPeriod([new Date(jamFrom), new Date(jamTo)]);
-  console.log('image in JamMake: ', image);
-
   const handleChatLink = e => {
     setChatLink(e.target.value);
   };

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -172,6 +172,10 @@ const JamMake = ({ isEdit }) => {
   const [currentTab, setCurrentTab] = useState(false);
   // const [isCreated, setIsCreated] = useState(false);
 
+  // const [image, setImage] = useState({
+  //   image_file: '',
+  //   previewURL: null,
+  // });
   const [image, setImage] = useState({
     image_file: '',
     previewURL: null,
@@ -335,6 +339,7 @@ const JamMake = ({ isEdit }) => {
 
   // setLocationText(jamData.location);
   // setPeriod([new Date(jamFrom), new Date(jamTo)]);
+  console.log('image in JamMake: ', image);
 
   const handleChatLink = e => {
     setChatLink(e.target.value);

--- a/client/src/Pages/Profile.js
+++ b/client/src/Pages/Profile.js
@@ -74,6 +74,8 @@ const validateText = css`
   min-width: 300px;
 `;
 
+const BASE_URL = `${process.env.REACT_APP_URL}`;
+
 const Profile = () => {
   const [image, setImage] = useState({
     image_file: '',
@@ -128,7 +130,8 @@ const Profile = () => {
           {
             nickname: userInput.nickname,
             password: userInput.password,
-            profileImage: userInput.profileImage,
+            // profileImage: userInput.profileImage,
+            profileImage: image.preview_URL,
           },
           {
             headers: {
@@ -137,7 +140,6 @@ const Profile = () => {
           },
         )
         .then(res => {
-          console.log(user);
           setUser({
             memberId: res.data.data.memberId,
             nickname: res.data.data.nickname,
@@ -150,27 +152,59 @@ const Profile = () => {
     }
   };
 
-  const saveImg = e => {
-    e.preventDefault();
-    const fileReader = new FileReader();
+  // const saveImg = e => {
+  //   e.preventDefault();
+  //   const fileReader = new FileReader();
 
-    if (e.target.files[0]) {
-      fileReader.readAsDataURL(e.target.files[0]);
-    }
-    fileReader.onload = () => {
-      setImage({
-        image_file: e.target.files[0],
-        preview_URL: `${fileReader.result}`,
+  //   if (e.target.files[0]) {
+  //     fileReader.readAsDataURL(e.target.files[0]);
+  //   }
+  //   fileReader.onload = () => {
+  //     setImage({
+  //       image_file: e.target.files[0],
+  //       preview_URL: `${fileReader.result}`,
+  //     });
+  //   };
+  // };
+
+  const saveImg = async e => {
+    e.preventDefault();
+    // eslint-disable-next-line no-shadow
+    // const img = e.target.files[0];
+    // console.log('img', img);
+    // setImage(e.target.files[0]);
+
+    const formData = new FormData();
+    formData.append('file', e.target.files[0]);
+
+    // eslint-disable-next-line no-undef
+    await axios
+      .post(`${BASE_URL}/upload`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
+      .then(res => {
+        console.log('res.data: ', res.data);
+        // setUser(Object.assign(user, { img: res.data }));
+        setUser(prevState => ({ ...prevState, img: res.data }));
+        setImage({ preview_URL: res.data });
+      })
+      .catch(err => {
+        console.log(err.Error);
       });
-    };
   };
 
   const deleteImg = () => {
+    setUser({ img: '' });
     setImage({
       image_file: '',
       preview_URL: '',
     });
   };
+
+  console.log('user: ', user);
+  console.log('userInput: ', userInput);
 
   return (
     <div className={pageContainer}>


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
1. 스터디, 잼 상세페이지 상에 위치를 지도로 반영
2. 상세페이지 사이드 바에 모집완료와 취소, 참여완료와 취소 상태가 버튼 클릭시 바로 변환되도록 수정하고, 새로고침 후에도 유지
3. 스터디 위치 검색시 모달창에서 엔터를 누르면 api 요청이 수행되는 오류를 수정
4. 잼 개설시 이미지 등록과 유저 프로필에서 이미지 등록 구현
5. 잼에 참여할 경우 잼 상세페이지 사이드바에 참여 유저의 이미지가 표시되도록 구현

## 스크린샷
![image](https://user-images.githubusercontent.com/97942837/205325154-690b5348-4894-4d64-bd59-ccf2daae0b77.png)
![image](https://user-images.githubusercontent.com/97942837/205325248-72ca79dd-b827-41a4-a72f-eda3caba28ce.png)


