### PR TITLE
[client] 페이지네이션 오류 수정

### DIFF
--- a/client/src/Components/Card/JamPagination.js
+++ b/client/src/Components/Card/JamPagination.js
@@ -9,6 +9,7 @@ import { totalJamLength, pageNumber } from '../../Atom/atoms';
 export default function JamPagination() {
   const [totalJamCount] = useRecoilState(totalJamLength);
   const [pageNum, setNextPage] = useRecoilState(pageNumber);
+  React.useEffect(() => {}, [pageNum]);
   const handlePageClick = e => {
     console.log(e);
 

--- a/client/src/Components/Card/JamPagination.js
+++ b/client/src/Components/Card/JamPagination.js
@@ -8,11 +8,19 @@ import { totalJamLength, pageNumber } from '../../Atom/atoms';
 
 export default function JamPagination() {
   const [totalJamCount] = useRecoilState(totalJamLength);
-  const [, setNextPage] = useRecoilState(pageNumber);
+  const [pageNum, setNextPage] = useRecoilState(pageNumber);
   const handlePageClick = e => {
-    const nowPageNum = Number(e.target.outerText);
-    console.log(nowPageNum);
-    setNextPage(nowPageNum);
+    console.log(e);
+
+    if (e.target.dataset.testid === 'NavigateNextIcon')
+      setNextPage(pageNum + 1);
+    else if (e.target.dataset.testid === 'NavigateBeforeIcon')
+      setNextPage(pageNum - 1);
+    else {
+      const nowPageNum = Number(e.target.outerText);
+      console.log(nowPageNum);
+      setNextPage(nowPageNum);
+    }
   };
   return (
     <ThemeProvider theme={theme}>

--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -72,19 +72,21 @@ const Category = () => {
   const [jamData, setJamData] = useState([]);
   const [filteredData, setFilteredData] = useState('');
   const filterButtonGroup = ['전체', '실시간 잼', '스터디 잼'];
-  const [page] = useRecoilState(pageNumber);
+  const [page, setCurrentPage] = useRecoilState(pageNumber);
   const [size] = useState(6);
   const navigate = useNavigate();
   const [, setTotalJamCount] = useRecoilState(totalJamLength);
 
   useEffect(() => {
     // 잼 전체 개수 조회
-    const totalJam = fetchJamRead('/jams');
-
+    const totaljamEndpoint =
+      currentCategory.label === '전체'
+        ? '/jams'
+        : `/jams/category?category=${currentCategory.param}&page=1&size=${size}`;
+    const totalJam = fetchJamRead(totaljamEndpoint);
     totalJam.then(data => {
-      const totalLength = data.content.length;
-      console.log(totalLength);
-      data.content[0].jamId % size === 0
+      const totalLength = data.totalElements;
+      totalLength % size === 0
         ? setTotalJamCount(Math.floor(totalLength / size))
         : setTotalJamCount(Math.floor(totalLength / size) + 1);
     });
@@ -108,6 +110,10 @@ const Category = () => {
       });
     }
   }, [currentCategory, page]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [currentCategory]);
 
   const handleFilterClick = (_, label) => {
     if (label === '실시간 잼')


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 카테고리별 데이터 불러오기에 페이지네이션을 적용했습니다.
- 페이지네이션의 이전과 다음 버튼 클릭시 발생하는 오류를 수정해 이전과 다음 페이지로 이동하도록 수정했습니다.
- 첫페이지에서 이전과 다음이 작동하지 않는 오류를 수정했습니다.

## 스크린샷
![Kapture 2022-12-04 at 13 00 19](https://user-images.githubusercontent.com/53070295/205473694-45b86622-e83e-48d3-97c7-d4c5edc4920a.gif)



