### PR TITLE
[client] 마감된 잼의 참여 버튼 활성화 상태 수정

### DIFF
--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -393,7 +393,15 @@ const JamSideBar = ({
       {nickname !== currentUser.nickname ? (
         <div css={ButtonContainer}>
           {!isJoiner ? (
-            <button type="button" css={RegisterButton} onClick={handleJoin}>
+            <button
+              type="button"
+              css={RegisterButton}
+              onClick={handleJoin}
+              disabled={isComplete === 'TRUE'}
+              style={
+                isComplete === 'TRUE' ? { backgroundColor: '#bababa' } : null
+              }
+            >
               참여하기
             </button>
           ) : (

--- a/client/src/Components/jamDetailComponent/ReReply.js
+++ b/client/src/Components/jamDetailComponent/ReReply.js
@@ -133,7 +133,7 @@ const ReReply = ({ openRe, setOpenRe, jamData, commentId, btnIdx }) => {
         `${BASE_URL}/jams/${jamData.jamId}/comments/${commentId}/replies`,
         {
           commentId,
-          content: 'kkk',
+          content: reVal,
         },
         {
           headers: {


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
마감된 잼의 참여 버튼 활성화 상태를 버튼 disabled와 버튼 색 변경으로 수정하였습니다

## 스크린샷
![image](https://user-images.githubusercontent.com/97942837/205473993-46320d3c-f5df-47f7-9eb5-b2a127228d14.png)
