### PR TITLE
[client] 검색 결과 페이지네이션 오류 수정

### DIFF
--- a/client/src/Atom/atoms.js
+++ b/client/src/Atom/atoms.js
@@ -3,8 +3,8 @@ import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
-const totalJamLength = atom({
-  key: 'totalJamLength',
+const totalPageNumber = atom({
+  key: 'totalPageNumber',
   default: 0,
 });
 
@@ -92,7 +92,7 @@ const myPageInfoState = atom({
 });
 
 export {
-  totalJamLength,
+  totalPageNumber,
   pageNumber,
   location,
   coordinate,

--- a/client/src/Components/Card/JamPagination.js
+++ b/client/src/Components/Card/JamPagination.js
@@ -4,12 +4,12 @@ import Stack from '@mui/material/Stack';
 import { ThemeProvider } from '@mui/material';
 import { useRecoilState } from 'recoil';
 import { theme } from '../../Styles/theme';
-import { totalJamLength, pageNumber } from '../../Atom/atoms';
+import { totalPageNumber, pageNumber } from '../../Atom/atoms';
 
 export default function JamPagination() {
-  const [totalJamCount] = useRecoilState(totalJamLength);
+  const [totalPage] = useRecoilState(totalPageNumber);
   const [pageNum, setNextPage] = useRecoilState(pageNumber);
-  React.useEffect(() => {}, [pageNum]);
+  React.useEffect(() => {}, [pageNum, totalPage]);
   const handlePageClick = e => {
     if (e.target.dataset.testid === 'NavigateNextIcon')
       setNextPage(pageNum + 1);
@@ -24,7 +24,7 @@ export default function JamPagination() {
     <ThemeProvider theme={theme}>
       <Stack spacing={2}>
         <Pagination
-          count={totalJamCount}
+          count={totalPage}
           color="primary"
           onClick={handlePageClick}
         />

--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -8,11 +8,11 @@ import { ButtonGroup, Button } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { fetchJamRead, fetchJamSearch } from '../Utils/fetchJam';
+import { fetchJamRead } from '../Utils/fetchJam';
 import { theme } from '../Styles/theme';
 import Sidebar from '../Components/Sidebar';
 import JamCard from '../Components/Card/JamCard';
-import { pageNumber, selectedCategory, totalJamLength } from '../Atom/atoms';
+import { pageNumber, selectedCategory, totalPageNumber } from '../Atom/atoms';
 import ScrollToTop from '../ScrollToTop';
 import { NoCategoryData } from '../Components/NoData';
 import JamPagination from '../Components/Card/JamPagination';
@@ -74,27 +74,17 @@ const Category = () => {
   const [page, setCurrentPage] = useRecoilState(pageNumber);
   const [size] = useState(6);
   const navigate = useNavigate();
-  const [, setTotalJamCount] = useRecoilState(totalJamLength);
+  const [, setTotalPage] = useRecoilState(totalPageNumber);
 
   useEffect(() => {
-    const totaljamEndpoint =
-      currentCategory.label === '전체'
-        ? '/jams'
-        : `/jams/category?category=${currentCategory.param}&page=1&size=${size}`;
-    const totalJam = fetchJamRead(totaljamEndpoint);
-    totalJam.then(data => {
-      const totalLength = data.totalElements;
-      totalLength % size === 0
-        ? setTotalJamCount(Math.floor(totalLength / size))
-        : setTotalJamCount(Math.floor(totalLength / size) + 1);
-    });
-
     if (currentCategory.label === '내주변') navigate('/home');
     if (searchText) {
-      const Jams = fetchJamSearch(searchText);
+      const endpoint = `/jams/search?keyword=${searchText}&page=${page}&size=${size}`;
+      const Jams = fetchJamRead(endpoint);
       Jams.then(data => {
         setJamData(data.content);
         setFilteredData(data.content);
+        setTotalPage(data.totalPages);
       });
     } else {
       const endpoint =
@@ -105,6 +95,7 @@ const Category = () => {
       searchJams.then(data => {
         setJamData(data.content);
         setFilteredData(data.content);
+        setTotalPage(data.totalPages);
       });
     }
   }, [currentCategory, page]);


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 검색 결과 조회시 페이지네이션이 적용되지 않던 오류를 수정했습니다.
- 검색결과와 잼 조회에서 적용중인 페이지네이션의 계산을 제거하고 응답의 totalPages를 전체 페이지 개수로 적용하도록 수정했습니다.

## 스크린샷
![Kapture 2022-12-05 at 18 35 01](https://user-images.githubusercontent.com/53070295/205603516-39886337-6175-41dd-b420-d032b9a7e32f.gif)


