### PR TITLE
[client] 지도 이동시 중심 동네로 바로 이동하는 오류 수정

### DIFF
--- a/client/src/Atom/atoms.js
+++ b/client/src/Atom/atoms.js
@@ -18,6 +18,11 @@ const location = atom({
   default: '서울특별시 강서구 마곡동',
 });
 
+const locationChanged = atom({
+  key: 'locationChanged',
+  default: false,
+});
+
 const coordinate = atom({
   key: 'coordinate',
   default: {
@@ -95,6 +100,7 @@ export {
   totalPageNumber,
   pageNumber,
   location,
+  locationChanged,
   coordinate,
   selectedCategory,
   isLoginState,

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -17,7 +17,7 @@ import { ThemeProvider } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { palette, theme } from '../../Styles/theme';
 import getJuso from './getJuso';
-import { location } from '../../Atom/atoms';
+import { location, locationChanged } from '../../Atom/atoms';
 
 const addressContainer = css`
   display: flex;
@@ -107,9 +107,11 @@ export default function AddressDialog() {
   };
 
   const [, setCurrentLocation] = useRecoilState(location);
+  const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
 
   const onSubmit = () => {
     setCurrentLocation(`${city} ${gu} ${dong}`);
+    setIsUserLocationChanged(true);
     handleClose();
   };
 

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/prop-types */
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
-import { location, coordinate } from '../../Atom/atoms';
+import { location, coordinate, locationChanged } from '../../Atom/atoms';
 
 const { kakao } = window;
 const Map = ({ jamData }) => {
@@ -12,7 +12,8 @@ const Map = ({ jamData }) => {
 
   const [currentLocation, setCurrentLocation] = useRecoilState(location);
   const [, setCurrentCoordinate] = useRecoilState(coordinate);
-
+  const [isUserLocationChanged, setIsUserLocationChanged] =
+    useRecoilState(locationChanged);
   function getMap() {
     const container = document.getElementById('map');
     const options = {
@@ -33,6 +34,7 @@ const Map = ({ jamData }) => {
         latitude: latlng.getLat(),
         longitude: latlng.getLng(),
       });
+      setIsUserLocationChanged(false);
     });
 
     // 주소-좌표 변환 객체를 생성합니다
@@ -51,8 +53,7 @@ const Map = ({ jamData }) => {
         for (let i = 0; i < result.length; i += 1) {
           // 행정동의 region_type 값은 'H' 이므로
           if (result[i].region_type === 'H') {
-            const locationName = result[i].address_name.split(' ');
-            setCurrentLocation(locationName[locationName.length - 1]);
+            setCurrentLocation(result[i].address_name);
             break;
           }
         }
@@ -109,7 +110,8 @@ const Map = ({ jamData }) => {
   };
 
   useEffect(() => {
-    ps.keywordSearch(currentLocation, placesSearchCB);
+    if (isUserLocationChanged)
+      ps.keywordSearch(currentLocation, placesSearchCB);
   }, [currentLocation]);
 
   useEffect(() => {


### PR DESCRIPTION


## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 지도 이동시 유저가 이동한 만큼이 아닌 지도의 중심에 있는 동네로 재검색후 이동하는 오류를 수정했습니다.
- 키워드로 동네 검색시 00동이 아닌 행정시도부터 검색하도록 수정했습니다.
