### PR TITLE
[client] 홈 카드 css 속성 추가

### DIFF
--- a/client/src/Components/Card/LongJamCard.js
+++ b/client/src/Components/Card/LongJamCard.js
@@ -61,12 +61,14 @@ const topInfo = css`
     font-size: 16px;
     font-weight: bold;
     margin: 0px 5px;
+    word-break: keep-all;
   }
   div {
     border-radius: 10px;
     padding: 3px 20px;
     margin: 0px 5px;
     font-size: 12px;
+    white-space: nowrap;
   }
 `;
 


### PR DESCRIPTION
## PR 전 확인 사항
- [X]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용

- 홈 화면의 잼 카드의 모집중/실시간 태그가 다음줄로 넘어가는 부분을 수정했습니다.
- 홈 화면의 잼 카드의 제목이 길 경우 단어 단위로 다음줄로 넘어가도록 수정했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/53070295/205933926-51c79c69-ddf4-42e2-bf24-a59372da17b6.png)
![image](https://user-images.githubusercontent.com/53070295/205934078-d5aabb75-f6fb-4de9-a82e-9bf5c1932068.png)
