### PR TITLE
[client] 헤더, 카테고리 디자인 반응형으로 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12505,12 +12505,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-      "peer": true
-    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -17508,19 +17502,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ua-parser-js": {
       "version": "0.7.32",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
@@ -20005,14 +19986,12 @@
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
-      "requires": {}
+      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
     },
     "@csstools/selector-specificity": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-      "requires": {}
+      "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg=="
     },
     "@emotion/babel-plugin": {
       "version": "11.10.5",
@@ -20140,8 +20119,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-      "requires": {}
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -20882,8 +20860,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -21019,8 +20996,7 @@
     "@mui/types": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.1.tgz",
-      "integrity": "sha512-c5mSM7ivD8EsqK6HUi9hQPr5V7TJ/IRThUQ9nWNYPdhCGriTSQV4vL6DflT99LkM+wLiIS1rVjphpEWxERep7A==",
-      "requires": {}
+      "integrity": "sha512-c5mSM7ivD8EsqK6HUi9hQPr5V7TJ/IRThUQ9nWNYPdhCGriTSQV4vL6DflT99LkM+wLiIS1rVjphpEWxERep7A=="
     },
     "@mui/utils": {
       "version": "5.10.14",
@@ -21112,8 +21088,7 @@
     "@react-oauth/google": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.5.0.tgz",
-      "integrity": "sha512-3bS+DmKjynzdn3dwdNFdiIybRTOhF2siVI+gjSZrsYI52oWKVqb8mkxsV3YbU/EnL/c5g9zBinGcbzTNUHq/eg==",
-      "requires": {}
+      "integrity": "sha512-3bS+DmKjynzdn3dwdNFdiIybRTOhF2siVI+gjSZrsYI52oWKVqb8mkxsV3YbU/EnL/c5g9zBinGcbzTNUHq/eg=="
     },
     "@remix-run/router": {
       "version": "1.0.3",
@@ -22331,14 +22306,12 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "requires": {}
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -22676,8 +22649,7 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "requires": {}
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -22732,8 +22704,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "requires": {}
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
@@ -23382,8 +23353,7 @@
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "requires": {}
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -23459,8 +23429,7 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "requires": {}
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
     },
     "css-select": {
       "version": "4.3.0",
@@ -23573,8 +23542,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -24344,8 +24312,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -24550,8 +24517,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "requires": {}
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
     },
     "eslint-plugin-testing-library": {
       "version": "5.9.1",
@@ -25063,8 +25029,7 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "requires": {}
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -25631,8 +25596,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "idb": {
       "version": "7.1.1",
@@ -26747,8 +26711,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -27507,12 +27470,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-      "peer": true
-    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -28068,8 +28025,7 @@
     "mui-nested-menu": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mui-nested-menu/-/mui-nested-menu-3.1.0.tgz",
-      "integrity": "sha512-no4Pp4QsmOhDcNM9hS6ZzGuOAfCGg0YsCir1latSpXNvMia0yovFE3XHKvmu9Dr2NradU06+C6rTIyTXuxtBqA==",
-      "requires": {}
+      "integrity": "sha512-no4Pp4QsmOhDcNM9hS6ZzGuOAfCGg0YsCir1latSpXNvMia0yovFE3XHKvmu9Dr2NradU06+C6rTIyTXuxtBqA=="
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -28577,8 +28533,7 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "requires": {}
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -28676,26 +28631,22 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "requires": {}
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-double-position-gradients": {
       "version": "3.1.2",
@@ -28717,8 +28668,7 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "requires": {}
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -28739,14 +28689,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
-      "requires": {}
+      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
     },
     "postcss-image-set-function": {
       "version": "4.0.7",
@@ -28769,8 +28717,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -28811,14 +28758,12 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "requires": {}
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "requires": {}
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
     },
     "postcss-merge-longhand": {
       "version": "5.1.7",
@@ -28879,8 +28824,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "requires": {}
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -28938,8 +28882,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -29032,8 +28975,7 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -29127,8 +29069,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "6.0.1",
@@ -29439,8 +29380,7 @@
     "react-daum-postcode": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.1.tgz",
-      "integrity": "sha512-IFlC8XBSK+uobSIBHaWlxeecYpv9RhCFNu4YJ3+CrfGyEVdc4+yaaUH6BIfJbTZOybVx0V3s4nUeAEsssXBNJg==",
-      "requires": {}
+      "integrity": "sha512-IFlC8XBSK+uobSIBHaWlxeecYpv9RhCFNu4YJ3+CrfGyEVdc4+yaaUH6BIfJbTZOybVx0V3s4nUeAEsssXBNJg=="
     },
     "react-dev-utils": {
       "version": "12.0.1",
@@ -29574,8 +29514,7 @@
     "react-icons": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
-      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
-      "requires": {}
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g=="
     },
     "react-is": {
       "version": "17.0.2",
@@ -29728,8 +29667,7 @@
     "recoil-persist": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
-      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
-      "requires": {}
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA=="
     },
     "recompose": {
       "version": "0.26.0",
@@ -30144,8 +30082,7 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "requires": {}
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -30357,8 +30294,7 @@
     "slick-carousel": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
-      "requires": {}
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
     },
     "sockjs": {
       "version": "0.3.24",
@@ -30604,8 +30540,7 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "requires": {}
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -31013,12 +30948,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true
-    },
     "ua-parser-js": {
       "version": "0.7.32",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
@@ -31377,8 +31306,7 @@
         "ws": {
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "requires": {}
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
         }
       }
     },
@@ -31810,8 +31738,7 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/client/src/Components/Card/JamCard.js
+++ b/client/src/Components/Card/JamCard.js
@@ -20,11 +20,15 @@ const box = css`
 
 const topArea = css`
   display: flex;
+  flex-wrap: wrap;
+
   div {
     border-radius: 10px;
     padding: 5px 15px;
     font-size: 12px;
+    margin-bottom: 2px;
     margin-right: 5px;
+    white-space: nowrap;
   }
 `;
 
@@ -57,11 +61,12 @@ const defaultImage = css`
 const bottomArea = css`
   display: flex;
   flex-flow: column wrap;
-
   > p {
     font-size: 20px;
     font-weight: bold;
     margin: 5px 0px;
+    word-break: break-all;
+    word-wrap: break-word;
   }
 `;
 
@@ -73,6 +78,7 @@ const info = css`
       font-size: medium;
       font-weight: normal;
       padding-left: 5px;
+      word-break: keep-all;
     }
   }
 `;
@@ -80,6 +86,7 @@ const info = css`
 const infoTop = css`
   display: flex;
   margin-top: 10px;
+  white-space: nowrap;
 `;
 const infoBottom = css`
   display: flex;

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -25,6 +25,11 @@ const addressContainer = css`
   justify-content: center;
   margin: 5px 10px;
   padding: 20px;
+  white-space: nowrap;
+  @media screen and (max-width: 767px) {
+    margin: 0px;
+    padding: 0px;
+  }
 `;
 const addressBtn = css`
   background-color: ${palette.gray_4};
@@ -33,6 +38,11 @@ const addressBtn = css`
   text-align: center;
   border-radius: 10px;
   padding: 15px 30px;
+  @media screen and (max-width: 767px) {
+    margin: 0px;
+    padding: 0px;
+    background-color: transparent;
+  }
 `;
 
 export default function AddressDialog() {
@@ -122,12 +132,20 @@ export default function AddressDialog() {
   return (
     <div className={addressContainer}>
       <button className={addressBtn} onClick={handleClickOpen} type="button">
-        동네 선택
+        동네 선택 ▾
       </button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>동네를 선택해주세요!</DialogTitle>
         <DialogContent>
-          <Box component="form" sx={{ display: 'flex', flexWrap: 'wrap' }}>
+          <Box
+            component="form"
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
             <ThemeProvider theme={theme}>
               <FormControl sx={{ m: 1, minWidth: 120 }}>
                 <InputLabel id="demo-dialog-select-label">시/도</InputLabel>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -5,6 +5,7 @@ import InputBase from '@mui/material/InputBase';
 import { useRecoilState } from 'recoil';
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { Avatar } from '@mui/material/';
 import { palette } from '../../Styles/theme';
 import logoImage from '../../Assets/images/logo_header.png';
 import AddressDialog from './AddressDialog';
@@ -13,6 +14,9 @@ import { isLoginState, loginUserInfoState } from '../../Atom/atoms';
 
 const headerBox = css`
   height: 100px;
+  @media screen and (max-width: 767px) {
+    height: 70px;
+  }
 `;
 const header = css`
   padding: 10px 40px 10px 30px;
@@ -23,22 +27,36 @@ const header = css`
   border-bottom: 0.5px ${palette.border} solid;
   position: fixed;
   z-index: 10;
+  @media screen and (max-width: 767px) {
+    padding: 10px;
+    height: 70px;
+  }
 `;
 
 const logo = css`
   margin-left: 10px;
   width: 130px;
   cursor: pointer;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 
 const searchBar = css`
   display: flex;
   align-items: center;
+  justify-content: center;
   background-color: ${palette.gray_4};
   border-radius: 10px;
   padding: 20px;
   margin: 15px 10px;
   flex-grow: 1;
+  @media screen and (max-width: 767px) {
+    padding: 10px 0px;
+    margin: 0px 10px;
+    background-color: transparent;
+    border: 1px solid ${palette.gray_4};
+  }
 `;
 
 const rightHeader = css`
@@ -46,12 +64,28 @@ const rightHeader = css`
   align-items: center;
   justify-content: center;
   margin-left: 40px;
+  white-space: nowrap;
+  @media screen and (max-width: 767px) {
+    margin: 0px;
+  }
 `;
 const loginBtn = css`
   border-radius: 10px;
   padding: 15px 40px;
   background-color: ${palette.gray_5};
   cursor: pointer;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
+const avataBtn = css`
+  display: none;
+  cursor: pointer;
+  @media screen and (max-width: 767px) {
+    display: inline;
+    cursor: pointer;
+  }
 `;
 
 const createJamBtn = css`
@@ -65,9 +99,15 @@ const createJamBtn = css`
     background-color: ${palette.colorAccent};
     color: ${palette.white};
   }
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 const username = css`
   margin: 10px;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 
 const Search = styled('div')(({ theme }) => ({
@@ -135,6 +175,9 @@ const LoginArea = () => {
     <div className={rightHeader}>
       <Link to="/login">
         {' '}
+        <div className={avataBtn}>
+          <Avatar sx={{ width: 32, height: 32 }} />
+        </div>
         <button type="button" className={loginBtn}>
           로그인{' '}
         </button>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -6,6 +6,8 @@ import { useRecoilState } from 'recoil';
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { Avatar } from '@mui/material/';
+import { MdArrowBack } from 'react-icons/md';
+import { IconButton } from '@material-ui/core';
 import { palette } from '../../Styles/theme';
 import logoImage from '../../Assets/images/logo_header.png';
 import AddressDialog from './AddressDialog';
@@ -30,6 +32,13 @@ const header = css`
   @media screen and (max-width: 767px) {
     padding: 10px;
     height: 70px;
+  }
+`;
+
+const backBtn = css`
+  display: none;
+  @media screen and (max-width: 767px) {
+    display: flex;
   }
 `;
 
@@ -142,6 +151,20 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   },
 }));
 
+const BackBtn = () => {
+  const navigate = useNavigate();
+  const handleBackBtnClick = () => {
+    navigate(-1);
+  };
+  return (
+    <div className={backBtn}>
+      <IconButton aria-label="back" onClick={handleBackBtnClick}>
+        <MdArrowBack fontSize="large" />
+      </IconButton>
+    </div>
+  );
+};
+
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
@@ -213,6 +236,7 @@ const Header = () => {
         <Link to="/" onClick={() => sessionStorage.clear}>
           <img className={logo} alt="logo_jamit" src={logoImage} />
         </Link>
+        <BackBtn className={backBtn} />
         <AddressDialog />
         <SearchBar />
         {!isLogin ? <LoginArea /> : <LogoutArea />}

--- a/client/src/Components/Sidebar.js
+++ b/client/src/Components/Sidebar.js
@@ -40,11 +40,8 @@ const sidebar = css`
     flex-direction: column;
     @media screen and (max-width: 767px) {
       flex-direction: row;
-      overflow: auto;
+      overflow: scroll;
       margin: 0;
-      ::-webkit-scrollbar {
-        display: none;
-      }
     }
   }
 

--- a/client/src/Components/Sidebar.js
+++ b/client/src/Components/Sidebar.js
@@ -15,6 +15,13 @@ const sidebar = css`
   border: 1px ${palette.gray_4} solid;
   display: flex;
   flex-direction: column;
+  white-space: nowrap;
+  @media screen and (max-width: 767px) {
+    width: 100%;
+    height: 70px;
+    flex-direction: row;
+    padding-bottom: 0px;
+  }
 
   & > div {
     display: flex;
@@ -22,10 +29,25 @@ const sidebar = css`
     align-items: center;
     height: 50px;
     background-color: ${palette.colorMain};
+    @media screen and (max-width: 767px) {
+      height: 50px;
+      display: none;
+    }
   }
   & > ul {
     padding: 10px;
+    display: flex;
+    flex-direction: column;
+    @media screen and (max-width: 767px) {
+      flex-direction: row;
+      overflow: auto;
+      margin: 0;
+      ::-webkit-scrollbar {
+        display: none;
+      }
+    }
   }
+
   & > ul > li {
     padding: 12px;
     border-radius: 5px;
@@ -37,6 +59,13 @@ const sidebar = css`
 
     &:hover {
       background-color: ${palette.colorMain};
+    }
+
+    @media screen and (max-width: 767px) {
+      background-color: ${palette.gray_4};
+      border-radius: 50px;
+      display: inline-block;
+      padding: 12px;
     }
   }
 `;

--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -19,6 +19,9 @@ import JamPagination from '../Components/Card/JamPagination';
 
 const pagewithSidebar = css`
   display: flex;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+  }
 `;
 const category = css`
   display: flex;
@@ -30,9 +33,13 @@ const topContainer = css`
   width: 100%;
   justify-content: space-between;
   padding: 20px 50px;
-
+  white-space: nowrap;
+  flex-wrap: wrap;
   p {
     margin: 10px;
+    @media screen and (max-width: 767px) {
+      margin: 0px 0px 10px 0px;
+    }
   }
   & ButtonGroup {
     justify-content: end;

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -14,6 +14,9 @@ import { NoNearyByData } from '../Components/NoData';
 
 const pagewithSidebar = css`
   display: flex;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+  }
 `;
 const home = css`
   display: flex;

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -19,6 +19,16 @@ import Reply from '../Components/jamDetailComponent/Reply';
 const MergeContainer = css`
   width: 100%;
   display: flex;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+  }
+`;
+
+const sidebarContainer = css`
+  display: flex;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 
 const Container = css`
@@ -151,7 +161,9 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
 
   return (
     <div css={MergeContainer}>
-      <Sidebar />
+      <div css={sidebarContainer}>
+        <Sidebar />
+      </div>
       <main css={Container}>
         <div css={SectionContainer}>
           <ThemeProvider theme={palette}>

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -25,6 +25,13 @@ const MergeContainer = css`
   align-items: flex-start;
 `;
 
+const sidebarContainer = css`
+  display: flex;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
 const Container = css`
   margin: 10px 30px;
   width: 100%;
@@ -335,7 +342,9 @@ const JamMake = ({ isEdit }) => {
 
   return (
     <div css={MergeContainer}>
-      <Sidebar />
+      <div css={sidebarContainer}>
+        <Sidebar />
+      </div>
       <div css={Container}>
         <header css={Header}>
           <div css={HeaderTap}>

--- a/client/src/Pages/Mypage.js
+++ b/client/src/Pages/Mypage.js
@@ -18,6 +18,14 @@ const pageContainer = css`
     gap: 40px;
   }
 `;
+
+const sidebarContainer = css`
+  display: flex;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
 const userContainer = css`
   width: 800px;
   min-width: 400px;
@@ -120,7 +128,9 @@ const Mypage = () => {
 
   return (
     <div className={pageContainer}>
-      <Sidebar />
+      <div className={sidebarContainer}>
+        <Sidebar />
+      </div>
       <div className={userContainer}>
         <UserTitle />
         <div className={userJamInfo}>

--- a/client/src/Pages/Profile.js
+++ b/client/src/Pages/Profile.js
@@ -20,6 +20,13 @@ const pageContainer = css`
   }
 `;
 
+const sidebarContainer = css`
+  display: flex;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
 const userContainer = css`
   padding: 40px;
   width: 700px;
@@ -214,7 +221,9 @@ const Profile = () => {
 
   return (
     <div className={pageContainer}>
-      <Sidebar />
+      <div className={sidebarContainer}>
+        <Sidebar />
+      </div>
       <ThemeProvider theme={themeUserPage}>
         <Box
           component="form"


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 윈도우창 width 767px 이하에서의 헤더 디자인을 다음과 같이 변경했습니다.
    - 로고와 잼생성 버튼을 삭제했습니다.
    - 뒤로가기 버튼을 추가했습니다.
    - 로그인 버튼 대신 기본 아바타 이미지로 로그인 버튼을 교체했습니다.
    - 동네선택 dialog의 select가 가운데정렬 되도록 수정했습니다.

- 윈도우창 width 767px 이하에서의 카테고리(사이드바)가 첨부된 페이지들의 디자인을 다음과 같이 변경했습니다.
     - 카테고리를 좌측이아닌 상단으로 옮기고 가로로 정렬해 횡스크롤로 변경했습니다.
    - jamDetail, jamMake, mypage, profile의 경우 사이드바를 보이지 않도록 변경했습니다.
    - categoryResult, home의 경우 flex-direction을 수정하여 세로로 카테고리와 결과가 보이도록 변경했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/53070295/207605610-c6d991a9-bd6c-4d92-a283-55ae5696ef4a.png)

## 리뷰
카테고리를 사용하는 페이지들에서 ui변화가 있습니다. 수정시 참고해주세요.

