### PR TITLE
[client] 잼 개설페이지, 상세페이지 반응형 디자인 적용

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,7 +37,7 @@ function App() {
           />
           <Route
             path="/jamdetail/:id"
-            element={<JamDetail isEdit={isEdit} setIsEdit={setIsEdit} />}
+            element={<JamDetail setIsEdit={setIsEdit} />}
           />
           <Route path="*" element={<PageNotFound />} />
         </Routes>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -108,9 +108,9 @@ const createJamBtn = css`
     background-color: ${palette.colorAccent};
     color: ${palette.white};
   }
-  @media screen and (max-width: 767px) {
+  /* @media screen and (max-width: 767px) {
     display: none;
-  }
+  } */
 `;
 const username = css`
   margin: 10px;

--- a/client/src/Components/jamCreateComponent/Description.js
+++ b/client/src/Components/jamCreateComponent/Description.js
@@ -12,6 +12,9 @@ const AboutStudy = css`
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
+  div {
+    width: 100%;
+  }
   span {
     margin-bottom: 5px;
   }
@@ -24,6 +27,7 @@ const AboutStudy = css`
   }
   @media screen and (max-width: 767px) {
     margin-bottom: 30px;
+    width: 100%;
   }
 `;
 
@@ -40,51 +44,51 @@ const Description = ({ desc, setDesc }) => {
             '& > :not(style)': {
               m: 0,
               width: {
-                tablet: 300,
+                mobile: '100%',
+                tablet: 650,
                 laptop: 800,
+                desktop: 800,
               },
             },
           }}
           noValidate
           autoComplete="off"
         >
-          <div>
-            <TextField
-              id="standard-basic"
-              label="스터디 소개"
-              multiline
-              rows={10}
-              variant="outlined"
-              placeholder="함께할 스터디를 소개해주세요"
-              value={desc || ''}
-              onChange={handleDesc}
-              sx={{
-                '& > :not(style)': {
-                  m: 0,
-                  width: {
-                    mobile: 650,
-                    tablet: 790,
-                    laptop: 790,
-                    desktop: 790,
-                  },
+          <TextField
+            id="standard-basic"
+            label="스터디 소개"
+            multiline
+            rows={10}
+            variant="outlined"
+            placeholder="함께할 스터디를 소개해주세요"
+            value={desc || ''}
+            onChange={handleDesc}
+            sx={{
+              '& > :not(style)': {
+                m: 0,
+                width: {
+                  mobile: '100%',
+                  tablet: '100%',
+                  laptop: 790,
+                  desktop: 790,
                 },
-                '& label, label.Mui-focused': {
-                  color: 'grey',
+              },
+              '& label, label.Mui-focused': {
+                color: 'grey',
+              },
+              '&.MuiOutlinedInput-root:hover': {
+                color: 'grey',
+              },
+              '& .MuiOutlinedInput-root': {
+                '& > fieldset': { borderColor: '#d2d2d2' },
+              },
+              '& .MuiOutlinedInput-root.Mui-focused': {
+                '& > fieldset': {
+                  borderColor: '#d2d2d2',
                 },
-                '&.MuiOutlinedInput-root:hover': {
-                  color: 'grey',
-                },
-                '& .MuiOutlinedInput-root': {
-                  '& > fieldset': { borderColor: '#d2d2d2' },
-                },
-                '& .MuiOutlinedInput-root.Mui-focused': {
-                  '& > fieldset': {
-                    borderColor: '#d2d2d2',
-                  },
-                },
-              }}
-            />
-          </div>
+              },
+            }}
+          />
         </Box>
       </ThemeProvider>
     </div>

--- a/client/src/Components/jamCreateComponent/Description.js
+++ b/client/src/Components/jamCreateComponent/Description.js
@@ -1,8 +1,9 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import { TextField, Box } from '@mui/material';
+import { theme } from '../../Styles/theme';
 
 const AboutStudy = css`
   margin-top: 20px;
@@ -21,6 +22,9 @@ const AboutStudy = css`
   input:focus {
     outline: none;
   }
+  @media screen and (max-width: 767px) {
+    margin-bottom: 30px;
+  }
 `;
 
 const Description = ({ desc, setDesc }) => {
@@ -30,43 +34,59 @@ const Description = ({ desc, setDesc }) => {
 
   return (
     <div css={AboutStudy}>
-      <Box
-        sx={{
-          '& > :not(style)': { m: 0, width: '800px' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <div>
-          <TextField
-            id="standard-basic"
-            label="스터디 소개"
-            multiline
-            rows={10}
-            variant="outlined"
-            placeholder="함께할 스터디를 소개해주세요"
-            value={desc || ''}
-            onChange={handleDesc}
-            sx={{
-              '& > :not(style)': { m: 0, width: '790px' },
-              '& label, label.Mui-focused': {
-                color: 'grey',
+      <ThemeProvider theme={theme}>
+        <Box
+          sx={{
+            '& > :not(style)': {
+              m: 0,
+              width: {
+                tablet: 300,
+                laptop: 800,
               },
-              '&.MuiOutlinedInput-root:hover': {
-                color: 'grey',
-              },
-              '& .MuiOutlinedInput-root': {
-                '& > fieldset': { borderColor: '#d2d2d2' },
-              },
-              '& .MuiOutlinedInput-root.Mui-focused': {
-                '& > fieldset': {
-                  borderColor: '#d2d2d2',
+            },
+          }}
+          noValidate
+          autoComplete="off"
+        >
+          <div>
+            <TextField
+              id="standard-basic"
+              label="스터디 소개"
+              multiline
+              rows={10}
+              variant="outlined"
+              placeholder="함께할 스터디를 소개해주세요"
+              value={desc || ''}
+              onChange={handleDesc}
+              sx={{
+                '& > :not(style)': {
+                  m: 0,
+                  width: {
+                    mobile: 650,
+                    tablet: 790,
+                    laptop: 790,
+                    desktop: 790,
+                  },
                 },
-              },
-            }}
-          />
-        </div>
-      </Box>
+                '& label, label.Mui-focused': {
+                  color: 'grey',
+                },
+                '&.MuiOutlinedInput-root:hover': {
+                  color: 'grey',
+                },
+                '& .MuiOutlinedInput-root': {
+                  '& > fieldset': { borderColor: '#d2d2d2' },
+                },
+                '& .MuiOutlinedInput-root.Mui-focused': {
+                  '& > fieldset': {
+                    borderColor: '#d2d2d2',
+                  },
+                },
+              }}
+            />
+          </div>
+        </Box>
+      </ThemeProvider>
     </div>
   );
 };

--- a/client/src/Components/jamCreateComponent/JamInputField.js
+++ b/client/src/Components/jamCreateComponent/JamInputField.js
@@ -2,8 +2,9 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
 import { TextField, Box, MenuItem } from '@mui/material';
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import KewordAddressModal from './KewordAddressModal';
+import { theme } from '../../Styles/theme';
 
 const Container = css`
   width: 100%;
@@ -20,7 +21,7 @@ const InputContainer = css`
 `;
 
 const JamNotice = css`
-  width: 100%;
+  width: 97%;
   height: 60px;
   padding: 10px;
   font-size: 15px;
@@ -84,108 +85,138 @@ const JamInputField = ({
 
   return (
     <div css={Container}>
-      <Box
-        sx={{
-          '& > :not(style)': { m: 1, width: '280px' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <div css={InputContainer}>
-          <TextField
-            id="study-name"
-            label="잼 이름"
-            variant="standard"
-            placeholder="실시간 잼의 이름을 지어주세요"
-            value={jamTitle || ''}
-            onChange={handleJamTitle}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' }, // 기본 라벨, 포커스시 라벨 색상
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
+      <ThemeProvider theme={theme}>
+        <Box
+          sx={{
+            '& > :not(style)': {
+              m: 1,
+              width: {
+                mobile: 290,
+                tablet: 290,
+                laptop: 290,
+                desktop: 290,
               },
-            }}
-          />
-          <TextField
-            id="study-category"
-            select
-            label="카테고리"
-            variant="standard"
-            name="category"
-            value={jamCategory || ''}
-            onChange={handleJamCategory}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          >
-            {categories.map(option => (
-              <MenuItem key={option.value} value={option.value || ''}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </TextField>
-          <TextField
-            id="study-location"
-            type="button"
-            onClick={handleOpen}
-            label="잼 위치"
-            variant="standard"
-            placeholder="클릭하면 주소 검색창이 나와요"
-            value={locationText || ''}
-            onChange={handleLocationText}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          />
-          {open && (
-            <KewordAddressModal
-              open={open}
-              handleClose={handleClose}
-              setOpen={setOpen}
-              locationText={locationText}
-              setLocationText={setLocationText}
-              setLatitude={setLatitude}
-              setLongitude={setLongitude}
-              setAddress={setAddress}
+            },
+          }}
+          noValidate
+          autoComplete="off"
+        >
+          <div css={InputContainer}>
+            <TextField
+              id="study-name"
+              label="잼 이름"
+              variant="standard"
+              placeholder="실시간 잼의 이름을 지어주세요"
+              value={jamTitle || ''}
+              onChange={handleJamTitle}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' }, // 기본 라벨, 포커스시 라벨 색상
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
             />
-          )}
-          <TextField
-            id="study-peopleNumber"
-            label="모집인원"
-            type="number"
-            variant="standard"
-            name="numberOfPeople"
-            InputProps={{ inputProps: { min: 0, max: 100 } }}
-            placeholder="숫자를 입력해주세요"
-            value={jamCapacity || ''}
-            onChange={handleJamCapacity}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          />
-          <div css={JamNotice}>
-            <span>실시간 잼은 개설 시점 기준으로 생성되며,</span>
-            <span>당일 자정이 지나면 자동으로 종료됩니다.</span>
+            <TextField
+              id="study-category"
+              select
+              label="카테고리"
+              variant="standard"
+              name="category"
+              value={jamCategory || ''}
+              onChange={handleJamCategory}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
+            >
+              {categories.map(option => (
+                <MenuItem key={option.value} value={option.value || ''}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              id="study-location"
+              type="button"
+              onClick={handleOpen}
+              label="잼 위치"
+              variant="standard"
+              placeholder="클릭하면 주소 검색창이 나와요"
+              value={locationText || ''}
+              onChange={handleLocationText}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
+            />
+            {open && (
+              <KewordAddressModal
+                open={open}
+                handleClose={handleClose}
+                setOpen={setOpen}
+                locationText={locationText}
+                setLocationText={setLocationText}
+                setLatitude={setLatitude}
+                setLongitude={setLongitude}
+                setAddress={setAddress}
+              />
+            )}
+            <TextField
+              id="study-peopleNumber"
+              label="모집인원"
+              type="number"
+              variant="standard"
+              name="numberOfPeople"
+              InputProps={{ inputProps: { min: 0, max: 100 } }}
+              placeholder="숫자를 입력해주세요"
+              value={jamCapacity || ''}
+              onChange={handleJamCapacity}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
+            />
+            <div css={JamNotice}>
+              <span>실시간 잼은 개설 시점 기준으로 생성되며,</span>
+              <span>당일 자정이 지나면 자동으로 종료됩니다.</span>
+            </div>
           </div>
-        </div>
-      </Box>
+        </Box>
+      </ThemeProvider>
     </div>
   );
 };

--- a/client/src/Components/jamCreateComponent/JamInputField.js
+++ b/client/src/Components/jamCreateComponent/JamInputField.js
@@ -8,7 +8,14 @@ import { theme } from '../../Styles/theme';
 
 const Container = css`
   width: 100%;
+  max-width: 280px;
   height: 356px;
+  @media screen and (max-width: 767px) {
+    max-width: 280px;
+  }
+  @media screen and (max-width: 479px) {
+    max-width: none;
+  }
 `;
 
 const InputContainer = css`
@@ -91,7 +98,7 @@ const JamInputField = ({
             '& > :not(style)': {
               m: 1,
               width: {
-                mobile: 290,
+                mobile: 360,
                 tablet: 290,
                 laptop: 290,
                 desktop: 290,
@@ -111,7 +118,7 @@ const JamInputField = ({
               onChange={handleJamTitle}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -133,7 +140,7 @@ const JamInputField = ({
               onChange={handleJamCategory}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -162,7 +169,7 @@ const JamInputField = ({
               onChange={handleLocationText}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -198,7 +205,7 @@ const JamInputField = ({
               onChange={handleJamCapacity}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,

--- a/client/src/Components/jamCreateComponent/KakaoMap.js
+++ b/client/src/Components/jamCreateComponent/KakaoMap.js
@@ -11,6 +11,10 @@ const mapContainer = css`
   position: relative;
   width: 800px;
   height: 600px;
+  @media screen and (max-width: 479px) {
+    width: 400px;
+    height: 600px;
+  }
 `;
 
 const resultContainer = css``;
@@ -28,6 +32,11 @@ const resultList = css`
   padding: 20px;
   background-color: rgba(240, 240, 240, 0.6);
   z-index: 5;
+  @media screen and (max-width: 479px) {
+    width: 250px;
+    height: 300px;
+    top: 75px;
+  }
 
   div {
     font-size: 15px;

--- a/client/src/Components/jamCreateComponent/KakaoMap.js
+++ b/client/src/Components/jamCreateComponent/KakaoMap.js
@@ -11,6 +11,9 @@ const mapContainer = css`
   position: relative;
   width: 800px;
   height: 600px;
+  @media screen and (max-width: 767px) {
+    width: 520px;
+  }
   @media screen and (max-width: 479px) {
     width: 400px;
     height: 600px;
@@ -32,6 +35,11 @@ const resultList = css`
   padding: 20px;
   background-color: rgba(240, 240, 240, 0.6);
   z-index: 5;
+  @media screen and (max-width: 767px) {
+    width: 250px;
+    height: 300px;
+    top: 95px;
+  }
   @media screen and (max-width: 479px) {
     width: 250px;
     height: 300px;

--- a/client/src/Components/jamCreateComponent/KewordAddressModal.js
+++ b/client/src/Components/jamCreateComponent/KewordAddressModal.js
@@ -2,14 +2,20 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Box, Typography, Modal } from '@mui/material';
+import { ThemeProvider } from '@emotion/react';
 import MapLanding from './MapLanding';
+import { theme } from '../../Styles/theme';
 
 const style = {
   position: 'absolute',
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: 850,
+  width: {
+    mobile: 'none',
+    tablet: 850,
+    laptop: 850,
+  },
   // border: '2px solid #000',
   display: 'flex',
   flexDirection: 'column',
@@ -33,18 +39,20 @@ const KewordAddressModal = ({
         onClose={handleClose}
         aria-labelledby="modal-modal-title"
       >
-        <Box sx={style}>
-          <Typography id="modal-modal-title" variant="h6" component="h2">
-            스터디할 장소를 키워드로 입력해보세요
-          </Typography>
-          <MapLanding
-            setLocationText={setLocationText}
-            handleClose={handleClose}
-            setLongitude={setLongitude}
-            setLatitude={setLatitude}
-            setAddress={setAddress}
-          />
-        </Box>
+        <ThemeProvider theme={theme}>
+          <Box sx={style}>
+            <Typography id="modal-modal-title" variant="h6" component="h2">
+              스터디할 장소를 키워드로 입력해보세요
+            </Typography>
+            <MapLanding
+              setLocationText={setLocationText}
+              handleClose={handleClose}
+              setLongitude={setLongitude}
+              setLatitude={setLatitude}
+              setAddress={setAddress}
+            />
+          </Box>
+        </ThemeProvider>
       </Modal>
     </div>
   );

--- a/client/src/Components/jamCreateComponent/MapLanding.js
+++ b/client/src/Components/jamCreateComponent/MapLanding.js
@@ -24,6 +24,9 @@ const inputForm = css`
   justify-content: center;
   align-items: center;
   background-color: rgba(240, 240, 240, 0.6);
+  @media screen and (max-width: 479px) {
+    top: 30px;
+  }
 
   input {
     color: #000;
@@ -35,6 +38,9 @@ const inputForm = css`
     border: 2px solid #bababa;
     border-radius: 5px;
     background-color: rgba(240, 240, 240, 0.6);
+    @media screen and (max-width: 479px) {
+      width: 185px;
+    }
   }
   button {
     color: #000;

--- a/client/src/Components/jamCreateComponent/MapLanding.js
+++ b/client/src/Components/jamCreateComponent/MapLanding.js
@@ -38,6 +38,9 @@ const inputForm = css`
     border: 2px solid #bababa;
     border-radius: 5px;
     background-color: rgba(240, 240, 240, 0.6);
+    @media screen and (max-width: 767px) {
+      width: 185px;
+    }
     @media screen and (max-width: 479px) {
       width: 185px;
     }

--- a/client/src/Components/jamCreateComponent/StudyInputField.js
+++ b/client/src/Components/jamCreateComponent/StudyInputField.js
@@ -244,7 +244,7 @@ const StudyInputField = ({
                 placement="bottomEnd"
                 // placement="topEnd"
                 // showOneCalendar="true"
-                preventOverflow="true"
+                preventOverflow
                 showMeridian
                 style={{ color: 'black' }}
                 name="period"

--- a/client/src/Components/jamCreateComponent/StudyInputField.js
+++ b/client/src/Components/jamCreateComponent/StudyInputField.js
@@ -7,15 +7,37 @@ import { css, ThemeProvider } from '@emotion/react';
 import { DateRangePicker } from 'rsuite';
 import KewordAddressModal from './KewordAddressModal';
 import { theme } from '../../Styles/theme';
+// import 'rsuite/dist/rsuite-rtl.css';
 
 const Container = css`
   width: 100%;
-  max-width: 300px;
+  max-width: 280px;
   height: 356px;
+  @media screen and (max-width: 767px) {
+    max-width: 220px;
+  }
+  @media screen and (max-width: 479px) {
+    max-width: none;
+  }
+  * {
+    .rs-picker
+      .rs-picker-menu
+      .rs-picker-daterange
+      .rs-picker-daterange-menu
+      .rs-picker-daterange-panel
+      .rs-stack
+      .rs-stack-item
+      .rs-picker-daterange-content
+      .rs-picker-daterange-calendar-group {
+      display: flex;
+      flex-direction: column;
+      height: auto;
+    }
+  }
 `;
 
 const InputContainer = css`
-  width: 100%;
+  /* width: 100%; */
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -24,7 +46,7 @@ const InputContainer = css`
 `;
 
 const PeriodContainer = css`
-  width: 97%;
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -95,7 +117,7 @@ const StudyInputField = ({
             '& > :not(style)': {
               m: 1,
               width: {
-                mobile: 290,
+                mobile: 360,
                 tablet: 290,
                 laptop: 290,
                 desktop: 290,
@@ -116,7 +138,7 @@ const StudyInputField = ({
               onChange={handleTitle}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -138,7 +160,7 @@ const StudyInputField = ({
               onChange={handleCategory}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -167,7 +189,7 @@ const StudyInputField = ({
               placeholder="클릭하면 주소 검색창이 나와요"
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -203,7 +225,7 @@ const StudyInputField = ({
               onChange={handleCapacity}
               sx={{
                 width: {
-                  mobile: 290,
+                  mobile: 360,
                   tablet: 290,
                   laptop: 290,
                   desktop: 290,
@@ -220,6 +242,9 @@ const StudyInputField = ({
               <DateRangePicker
                 format="yyyy-MM-dd hh:mm aa"
                 placement="bottomEnd"
+                // placement="topEnd"
+                // showOneCalendar="true"
+                preventOverflow="true"
                 showMeridian
                 style={{ color: 'black' }}
                 name="period"

--- a/client/src/Components/jamCreateComponent/StudyInputField.js
+++ b/client/src/Components/jamCreateComponent/StudyInputField.js
@@ -3,9 +3,10 @@
 import 'rsuite/dist/rsuite.min.css';
 import React, { useState } from 'react';
 import { TextField, Box, MenuItem } from '@mui/material';
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import { DateRangePicker } from 'rsuite';
 import KewordAddressModal from './KewordAddressModal';
+import { theme } from '../../Styles/theme';
 
 const Container = css`
   width: 100%;
@@ -23,7 +24,7 @@ const InputContainer = css`
 `;
 
 const PeriodContainer = css`
-  width: 100%;
+  width: 97%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -88,116 +89,147 @@ const StudyInputField = ({
 
   return (
     <div css={Container}>
-      <Box
-        sx={{
-          '& > :not(style)': { m: 1, width: '280px' },
-        }}
-        noValidate
-        autoComplete="off"
-      >
-        <div css={InputContainer}>
-          <TextField
-            id="study-name"
-            label="스터디 이름"
-            variant="standard"
-            name="title"
-            placeholder="스터디 이름을 지어주세요"
-            value={title || ''}
-            onChange={handleTitle}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' }, // 기본 라벨, 포커스시 라벨 색상
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
+      <ThemeProvider theme={theme}>
+        <Box
+          sx={{
+            '& > :not(style)': {
+              m: 1,
+              width: {
+                mobile: 290,
+                tablet: 290,
+                laptop: 290,
+                desktop: 290,
               },
-            }}
-          />
-          <TextField
-            id="study-category"
-            select
-            label="카테고리"
-            variant="standard"
-            name="category"
-            value={category || ''}
-            onChange={handleCategory}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          >
-            {categories.map(option => (
-              <MenuItem key={option.value} value={option.value || ''}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </TextField>
-          <TextField
-            id="study-location"
-            type="button"
-            onClick={handleOpen}
-            label="스터디 위치"
-            variant="standard"
-            value={locationText || ''}
-            onChange={handleLocationText}
-            placeholder="클릭하면 주소 검색창이 나와요"
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          />
-          {open && (
-            <KewordAddressModal
-              open={open}
-              handleClose={handleClose}
-              setOpen={setOpen}
-              locationText={locationText}
-              setLocationText={setLocationText}
-              setLatitude={setLatitude}
-              setLongitude={setLongitude}
-              setAddress={setAddress}
+            },
+          }}
+          noValidate
+          autoComplete="off"
+        >
+          <div css={InputContainer}>
+            <TextField
+              id="study-name"
+              label="스터디 이름"
+              variant="standard"
+              name="title"
+              placeholder="스터디 이름을 지어주세요"
+              value={title || ''}
+              onChange={handleTitle}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' }, // 기본 라벨, 포커스시 라벨 색상
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
             />
-          )}
-          <TextField
-            id="study-peopleNumber"
-            label="모집인원"
-            type="number"
-            variant="standard"
-            name="numberOfPeople"
-            InputProps={{ inputProps: { min: 0, max: 100 } }}
-            placeholder="숫자를 입력해주세요"
-            value={capacity || ''}
-            onChange={handleCapacity}
-            sx={{
-              width: 300,
-              maxWidth: '100%',
-              '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
-              '& .MuiInput-underline:after': {
-                borderBottomColor: 'black',
-              },
-            }}
-          />
-          <div css={PeriodContainer}>
-            <span>모집기간</span>
-            <DateRangePicker
-              format="yyyy-MM-dd hh:mm aa"
-              showMeridian
-              style={{ color: 'black' }}
-              name="period"
-              value={period}
-              onChange={handlePeriodChange}
+            <TextField
+              id="study-category"
+              select
+              label="카테고리"
+              variant="standard"
+              name="category"
+              value={category || ''}
+              onChange={handleCategory}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
+            >
+              {categories.map(option => (
+                <MenuItem key={option.value} value={option.value || ''}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              id="study-location"
+              type="button"
+              onClick={handleOpen}
+              label="스터디 위치"
+              variant="standard"
+              value={locationText || ''}
+              onChange={handleLocationText}
+              placeholder="클릭하면 주소 검색창이 나와요"
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
             />
+            {open && (
+              <KewordAddressModal
+                open={open}
+                handleClose={handleClose}
+                setOpen={setOpen}
+                locationText={locationText}
+                setLocationText={setLocationText}
+                setLatitude={setLatitude}
+                setLongitude={setLongitude}
+                setAddress={setAddress}
+              />
+            )}
+            <TextField
+              id="study-peopleNumber"
+              label="모집인원"
+              type="number"
+              variant="standard"
+              name="numberOfPeople"
+              InputProps={{ inputProps: { min: 0, max: 100 } }}
+              placeholder="숫자를 입력해주세요"
+              value={capacity || ''}
+              onChange={handleCapacity}
+              sx={{
+                width: {
+                  mobile: 290,
+                  tablet: 290,
+                  laptop: 290,
+                  desktop: 290,
+                },
+                maxWidth: '100%',
+                '& .MuiInputLabel-root.Mui-focused': { color: 'black' },
+                '& .MuiInput-underline:after': {
+                  borderBottomColor: 'black',
+                },
+              }}
+            />
+            <div css={PeriodContainer}>
+              <span>모집기간</span>
+              <DateRangePicker
+                format="yyyy-MM-dd hh:mm aa"
+                placement="bottomEnd"
+                showMeridian
+                style={{ color: 'black' }}
+                name="period"
+                value={period}
+                onChange={handlePeriodChange}
+              />
+            </div>
           </div>
-        </div>
-      </Box>
+        </Box>
+      </ThemeProvider>
     </div>
   );
 };

--- a/client/src/Components/jamDetailComponent/JamCarousel.js
+++ b/client/src/Components/jamDetailComponent/JamCarousel.js
@@ -18,6 +18,9 @@ const SliderStyle = styled(Slider)`
     height: 275px;
     object-fit: cover;
     border-radius: 3px;
+    @media screen and (max-width: 767px) {
+      width: 100%;
+    }
     @media screen and (max-width: 479px) {
       width: 100%;
     }
@@ -28,6 +31,9 @@ const SliderStyle = styled(Slider)`
     width: 560px;
     height: 100%;
     object-fit: cover;
+    @media screen and (max-width: 767px) {
+      width: 100%;
+    }
     @media screen and (max-width: 479px) {
       width: 100%;
     }

--- a/client/src/Components/jamDetailComponent/JamCarousel.js
+++ b/client/src/Components/jamDetailComponent/JamCarousel.js
@@ -18,6 +18,9 @@ const SliderStyle = styled(Slider)`
     height: 275px;
     object-fit: cover;
     border-radius: 3px;
+    @media screen and (max-width: 479px) {
+      width: 100%;
+    }
   }
 
   .slick-slide div {
@@ -25,6 +28,9 @@ const SliderStyle = styled(Slider)`
     width: 560px;
     height: 100%;
     object-fit: cover;
+    @media screen and (max-width: 479px) {
+      width: 100%;
+    }
     span {
       white-space: pre-line;
       object-fit: cover;

--- a/client/src/Components/jamDetailComponent/JamComments.js
+++ b/client/src/Components/jamDetailComponent/JamComments.js
@@ -41,13 +41,7 @@ const JamComments = ({
 }) => {
   return (
     <div css={Container}>
-      <div>
-        <WriteComment
-          text={text}
-          setText={setText}
-          handleSubmit={handleSubmit}
-        />
-      </div>
+      <WriteComment text={text} setText={setText} handleSubmit={handleSubmit} />
       <ThemeProvider theme={palette}>
         <hr />
       </ThemeProvider>

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -60,6 +60,13 @@ const TitleAndState = css`
 const Title = css`
   font-size: 24px;
   margin-bottom: 5px;
+  line-height: 25px;
+  @media screen and (max-width: 767px) {
+    font-size: 22px;
+  }
+  @media screen and (max-width: 479px) {
+    font-size: 18px;
+  }
 `;
 
 const MediaButton = css`

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -15,6 +15,8 @@ import jamElapsedTime from '../userComp/JamElapsedTime';
 import { categories } from '../jamCreateComponent/StudyInputField';
 import JamLocationMap from './JamLocationMap';
 import { loginUserInfoState } from '../../Atom/atoms';
+import JamSideBarButtonMedia from './JamSideBarButtonMedia';
+import JamSideBarStateMedia from './JamSideBarStateMedia';
 
 const Container = css`
   margin: 0 auto;
@@ -36,14 +38,37 @@ const HeaderContainer = css`
 
 const TitleContainer = css`
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  @media screen and (max-width: 767px) {
+    /* justify-content: flex-start; */
+    align-items: flex-start;
+    gap: 10px;
+  }
+`;
+
+const TitleAndState = css`
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 10px;
 `;
 
 const Title = css`
   font-size: 24px;
   margin-bottom: 5px;
+`;
+
+const MediaButton = css`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  @media screen and (min-width: 767px) {
+    display: none;
+  }
 `;
 
 const InfoIcons = css`
@@ -116,7 +141,14 @@ const EditButton = css`
   border-radius: 3px;
 `;
 
-const JamInfo = ({ setIsEdit, jamData }) => {
+const JamInfo = ({
+  setIsEdit,
+  jamData,
+  isComplete,
+  setIsComplete,
+  joiner,
+  setJoiner,
+}) => {
   const [currentUser] = useRecoilState(loginUserInfoState);
 
   const navigate = useNavigate();
@@ -147,7 +179,16 @@ const JamInfo = ({ setIsEdit, jamData }) => {
     <div css={Container}>
       <div css={HeaderContainer}>
         <div css={TitleContainer}>
-          <h2 css={Title}>{title}</h2>
+          <div css={TitleAndState}>
+            <h2 css={Title}>{title}</h2>
+            <JamSideBarStateMedia
+              jamData={jamData}
+              isComplete={isComplete}
+              setIsComplete={setIsComplete}
+              joiner={joiner}
+              setJoiner={setJoiner}
+            />
+          </div>
           {nickname === currentUser.nickname && (
             <button css={EditButton} type="button" onClick={handleIsEdit}>
               수정
@@ -213,6 +254,15 @@ const JamInfo = ({ setIsEdit, jamData }) => {
             {jamData && <JamLocationMap jamData={jamData} />}
           </div>
         </ThemeProvider>
+      </div>
+      <div css={MediaButton}>
+        <JamSideBarButtonMedia
+          jamData={jamData}
+          isComplete={isComplete}
+          setIsComplete={setIsComplete}
+          joiner={joiner}
+          setJoiner={setJoiner}
+        />
       </div>
     </div>
   );

--- a/client/src/Components/jamDetailComponent/JamSideBar.js
+++ b/client/src/Components/jamDetailComponent/JamSideBar.js
@@ -21,7 +21,6 @@ import UserName from '../userComp/UserName';
 
 const JamSideContainer = css`
   width: 220px;
-  /* min-width: 200px; */
   display: flex;
   position: sticky;
   left: 20px;
@@ -36,6 +35,9 @@ const JamSideContainer = css`
   font-size: 12px;
   padding: 15px;
   margin-top: 30px;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 
 const Header = css`

--- a/client/src/Components/jamDetailComponent/JamSideBarButtonMedia.js
+++ b/client/src/Components/jamDetailComponent/JamSideBarButtonMedia.js
@@ -1,0 +1,384 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable no-undef */
+/** @jsxImportSource @emotion/react */
+/* eslint-disable react/prop-types */
+import React, { useState, useEffect } from 'react';
+import { css } from '@emotion/react';
+import { FaUserCircle } from 'react-icons/fa';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useRecoilState } from 'recoil';
+import { getCookie } from '../SignComp/Cookie';
+import { loginUserInfoState } from '../../Atom/atoms';
+import UserName from '../userComp/UserName';
+
+const JamSideContainer = css`
+  width: 150px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  background-color: #fff;
+  gap: 5px;
+  font-size: 12px;
+  @media screen and (max-width: 767px) {
+    width: 100%;
+  }
+`;
+
+const UserAndStateBox = css`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  letter-spacing: 0.5px;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-end;
+    margin-top: 15px;
+  }
+`;
+
+const UserBox = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  letter-spacing: 0.5px;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
+const Title = css`
+  font-size: 16px;
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
+const AvatarContainer = css`
+  width: 100%;
+  height: fit-content;
+  display: flex;
+  img {
+    width: 30px;
+    height: 30px;
+    border-radius: 100px;
+    cursor: pointer;
+  }
+`;
+
+const ChatLink = css`
+  @media screen and (max-width: 767px) {
+    width: 100%;
+    margin: 10px 0;
+    display: flex;
+    gap: 5px;
+    font-size: 13px;
+  }
+`;
+
+const ButtonContainer = css`
+  width: 100%;
+  height: 35px;
+  @media screen and (max-width: 767px) {
+    margin-top: 5px;
+  }
+`;
+
+const RegisterButton = css`
+  width: 100%;
+  height: 100%;
+  border-style: none;
+  border-radius: 5px;
+  font-weight: 600;
+  background-color: #f33b06;
+  color: white;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background-color: #f25e36;
+  }
+`;
+
+const CloseJamButton = css`
+  background-color: #ff9b51;
+
+  &:hover {
+    background-color: #fd7e14;
+  }
+`;
+
+const CancleButton = css`
+  background-color: #bababa;
+  &:hover {
+    background-color: grey;
+  }
+`;
+
+const BASE_URL = `${process.env.REACT_APP_URL}`;
+
+// eslint-disable-next-line no-unused-vars
+const JamSideBarButtonMedia = ({
+  jamData,
+  isComplete,
+  setIsComplete,
+  joiner,
+  setJoiner,
+}) => {
+  const [currentUser] = useRecoilState(loginUserInfoState);
+
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  const accessToken = getCookie('accessToken');
+
+  const isJoiner =
+    joiner &&
+    joiner.filter(el => el.nickname === currentUser.nickname).length === 1;
+
+  const handleClose = async () => {
+    // eslint-disable-next-line no-restricted-globals
+    const confirmData = confirm('모집을 완료하시겠습니까?');
+
+    if (!accessToken) {
+      alert('토큰이 만료되었습니다');
+      navigate('/login');
+      window.location.reload();
+    }
+
+    if (confirmData && accessToken) {
+      if (accessToken) {
+        await axios
+          .post(
+            `${BASE_URL}/jams/${id}/complete/true`,
+            {},
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            },
+          )
+          .then(res => {
+            if (res.status === 200) {
+              setIsComplete('TRUE');
+            }
+          })
+          .catch(error => {
+            console.log(error.message);
+          });
+      }
+    }
+  };
+
+  const handleCancelClose = async () => {
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    const confirmData = confirm('모집완료를 취소하시겠습니까?');
+
+    if (!accessToken) {
+      alert('토큰이 만료되었습니다');
+      navigate('/login');
+      window.location.reload();
+    }
+
+    if (confirmData && accessToken) {
+      await axios
+        .delete(`${BASE_URL}/jams/${id}/complete/false`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        .then(res => {
+          if (res.status === 200) {
+            setIsComplete('FALSE');
+          }
+        })
+        .catch(error => {
+          console.log(error.message);
+        });
+    }
+  };
+
+  const handleJoin = async () => {
+    // eslint-disable-next-line no-restricted-globals
+
+    if (!accessToken) {
+      alert('토큰이 만료되었습니다');
+      navigate('/login');
+      window.location.reload();
+    }
+
+    await axios
+      .post(
+        `${BASE_URL}/jams/${id}/participation/true`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      )
+      .then(res => {
+        if (res.status === 200) {
+          setJoiner([...joiner, currentUser]);
+        }
+        window.location.reload();
+      })
+      .catch(error => {
+        console.log(error.message);
+      });
+  };
+
+  const handleWithdraw = async () => {
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    const confirmData = confirm('참여를 취소하시겠습니까?');
+
+    if (!accessToken) {
+      alert('토큰이 만료되었습니다');
+      navigate('/login');
+      window.location.reload();
+    }
+
+    if (confirmData && accessToken) {
+      await axios
+        .delete(`${BASE_URL}/jams/${id}/participation/false`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        .then(res => {
+          window.location.reload();
+          if (res.status === 200) {
+            setJoiner(
+              joiner.filter(el => el.nickname !== currentUser.nickname),
+            );
+          }
+        })
+        .catch(error => {
+          console.log(error.message);
+        });
+    }
+  };
+
+  const handleCardClick = memeberId => {
+    navigate(`/mypage/${memeberId}`);
+  };
+
+  const [jamOpener, setJamOpener] = useState({
+    memberId: '',
+    name: '',
+    img: '',
+  });
+
+  useEffect(() => {
+    if (jamData.participantList) {
+      setJamOpener({
+        memberId: jamData.participantList[0].memberId,
+        name: jamData.participantList[0].nickname,
+        img: jamData.participantList[0].profileImage,
+      });
+    }
+  }, [jamData.participantList]);
+
+  return (
+    <div css={JamSideContainer}>
+      <div css={UserAndStateBox}>
+        <div css={UserBox}>
+          <UserName
+            name={jamOpener.name}
+            id={jamOpener.memberId}
+            img={jamOpener.img}
+          />
+        </div>
+      </div>
+      <h6 css={Title}>{jamData.title}</h6>
+      {/* 스터디 개설 유저가 로그인 유저와 같지 않으면 참여 부분, 같으면 모집 부분 렌더 */}
+      {jamData.nickname !== currentUser.nickname ? (
+        <div css={ButtonContainer}>
+          {!isJoiner ? (
+            <button
+              type="button"
+              css={RegisterButton}
+              onClick={handleJoin}
+              disabled={isComplete === 'TRUE'}
+              style={
+                isComplete === 'TRUE' ? { backgroundColor: '#bababa' } : null
+              }
+            >
+              참여하기
+            </button>
+          ) : (
+            <button
+              type="button"
+              css={[RegisterButton, CancleButton]}
+              onClick={handleWithdraw}
+            >
+              참여취소하기
+            </button>
+          )}
+        </div>
+      ) : (
+        <div css={ButtonContainer}>
+          {isComplete === 'FALSE' ? (
+            <button
+              type="button"
+              css={[RegisterButton, CloseJamButton]}
+              onClick={handleClose}
+            >
+              모집 완료하기
+            </button>
+          ) : (
+            <button
+              type="button"
+              css={[RegisterButton, CloseJamButton, CancleButton]}
+              onClick={handleCancelClose}
+            >
+              모집완료 취소
+            </button>
+          )}
+        </div>
+      )}
+      {(isJoiner || jamData.nickname === currentUser.nickname) && (
+        <>
+          <div css={ChatLink}>
+            <span>채팅채널</span>
+            <br />
+            <span>
+              <a
+                href={jamData.openChatLink}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {jamData.openChatLink}
+              </a>
+            </span>
+          </div>
+          <div css={AvatarContainer}>
+            {jamData &&
+              jamData.participantList.map(el => {
+                return (
+                  <div
+                    key={el.memberId}
+                    className="imgContainer"
+                    onClick={() => handleCardClick(el.memberId)}
+                  >
+                    {el.profileImage ? (
+                      <img src={el.profileImage} alt={el.nickname} />
+                    ) : (
+                      <FaUserCircle size={32} />
+                    )}
+                  </div>
+                );
+              })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default JamSideBarButtonMedia;

--- a/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
+++ b/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
@@ -7,7 +7,7 @@ import { css } from '@emotion/react';
 import RecruitState from './RecruitState';
 
 const JamSideContainer = css`
-  width: 200px;
+  width: 70px;
   height: 100%;
   background-color: #fff;
   font-size: 12px;

--- a/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
+++ b/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
@@ -1,0 +1,48 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable no-undef */
+/** @jsxImportSource @emotion/react */
+/* eslint-disable react/prop-types */
+import { css } from '@emotion/react';
+import RecruitState from './RecruitState';
+
+const JamSideContainer = css`
+  width: 200px;
+  height: 100%;
+  background-color: #fff;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  @media screen and (min-width: 767px) {
+    display: none;
+  }
+`;
+
+const UserAndStateBox = css`
+  width: 100%;
+  display: flex;
+  letter-spacing: 0.5px;
+`;
+
+// eslint-disable-next-line no-unused-vars
+const JamSideBarStateMedia = ({ isComplete }) => {
+  return (
+    <div css={JamSideContainer}>
+      <div css={UserAndStateBox}>
+        {isComplete === 'FALSE' ? (
+          <RecruitState state="open" variant="colorJamOpen">
+            모집중
+          </RecruitState>
+        ) : (
+          <RecruitState state="close" variant="colorJamClose">
+            모집완료
+          </RecruitState>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default JamSideBarStateMedia;

--- a/client/src/Components/jamDetailComponent/WriteComment.js
+++ b/client/src/Components/jamDetailComponent/WriteComment.js
@@ -1,11 +1,12 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
 import { useRecoilState } from 'recoil';
 import { TextField, Box } from '@mui/material';
 import UserName from '../userComp/UserName';
 import { isLoginState, loginUserInfoState } from '../../Atom/atoms';
+import { theme } from '../../Styles/theme';
 
 const Container = css`
   width: 100%;
@@ -26,6 +27,11 @@ const UserBox = css`
 
 const InputBox = css`
   margin-bottom: 10px;
+  width: 100%;
+`;
+
+const ReplyInput = css`
+  width: 100%;
 `;
 
 const RegisterComment = css`
@@ -58,26 +64,80 @@ const WriteComment = ({ text, setText, handleSubmit }) => {
         )}
       </div>
       <div css={InputBox}>
-        <Box
-          component="form"
-          sx={{
-            '& > :not(style)': { m: 0, width: '518px' },
-          }}
-          noValidate
-          autoComplete="off"
-        >
-          {isLogin ? (
-            <>
+        <ThemeProvider theme={theme}>
+          <Box
+            component="form"
+            sx={{
+              '& > :not(style)': {
+                m: 0,
+                width: {
+                  mobile: '100%',
+                  tablet: '100%',
+                  laptop: 520,
+                  desktop: 540,
+                },
+              },
+            }}
+            noValidate
+            autoComplete="off"
+          >
+            {isLogin ? (
+              <div css={ReplyInput}>
+                <TextField
+                  hiddenLabel
+                  id="outlined-basic"
+                  variant="outlined"
+                  placeholder="댓글을 남겨주세요"
+                  multiline
+                  rows={2}
+                  value={text || ''}
+                  onChange={handleTextChange}
+                  sx={{
+                    width: {
+                      mobile: '100%',
+                      tablet: '100%',
+                      laptop: 520,
+                      desktop: 520,
+                    },
+                    backgroundColor: '#fff',
+                    borderRadius: 1,
+                    '.MuiOutlinedInput-root': {
+                      fontSize: '13px',
+                      '& fieldset': {
+                        border: 'none',
+                      },
+                    },
+                    '.MuiOutlinedInput-root.Mui-focused': {
+                      '& fieldset': {
+                        border: '3px solid #B0D0FF',
+                      },
+                    },
+                  }}
+                />
+                <div css={RegisterComment}>
+                  <button type="submit" onClick={handleSubmit}>
+                    등록
+                  </button>
+                </div>
+              </div>
+            ) : (
               <TextField
                 hiddenLabel
                 id="outlined-basic"
                 variant="outlined"
-                placeholder="댓글을 남겨주세요"
+                placeholder="댓글을 작성하려면 로그인 해주세요"
+                inputProps={{ readOnly: true }}
                 multiline
                 rows={2}
                 value={text || ''}
                 onChange={handleTextChange}
                 sx={{
+                  width: {
+                    mobile: 'none',
+                    tablet: '100%',
+                    laptop: 520,
+                    desktop: 520,
+                  },
                   backgroundColor: '#fff',
                   borderRadius: 1,
                   '.MuiOutlinedInput-root': {
@@ -93,41 +153,9 @@ const WriteComment = ({ text, setText, handleSubmit }) => {
                   },
                 }}
               />
-              <div css={RegisterComment}>
-                <button type="submit" onClick={handleSubmit}>
-                  등록
-                </button>
-              </div>
-            </>
-          ) : (
-            <TextField
-              hiddenLabel
-              id="outlined-basic"
-              variant="outlined"
-              placeholder="댓글을 작성하려면 로그인 해주세요"
-              inputProps={{ readOnly: true }}
-              multiline
-              rows={2}
-              value={text || ''}
-              onChange={handleTextChange}
-              sx={{
-                backgroundColor: '#fff',
-                borderRadius: 1,
-                '.MuiOutlinedInput-root': {
-                  fontSize: '13px',
-                  '& fieldset': {
-                    border: 'none',
-                  },
-                },
-                '.MuiOutlinedInput-root.Mui-focused': {
-                  '& fieldset': {
-                    border: '3px solid #B0D0FF',
-                  },
-                },
-              }}
-            />
-          )}
-        </Box>
+            )}
+          </Box>
+        </ThemeProvider>
       </div>
     </div>
   );

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -33,7 +33,7 @@ const MergeContainer = css`
 const sidebarContainer = css`
   display: flex;
   @media screen and (max-width: 767px) {
-    display: none;
+    width: 100%;
   }
 `;
 
@@ -44,12 +44,6 @@ const Container = css`
   align-items: flex-start;
   padding: 10px;
   gap: 20px;
-  @media screen and (max-width: 767px) {
-    margin: 10px 30px;
-  }
-  @media screen and (max-width: 479px) {
-    margin: 10px 30px;
-  }
 `;
 
 const SectionContainer = css`
@@ -58,6 +52,10 @@ const SectionContainer = css`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  @media screen and (max-width: 767px) {
+    padding: 0 10px;
+    width: 100%;
+  }
   @media screen and (max-width: 479px) {
     width: 100%;
   }
@@ -72,6 +70,11 @@ const JamContainer = css`
   align-items: center;
   padding: 20px;
   border-radius: 3px;
+  @media screen and (max-width: 767px) {
+    width: 100%;
+    padding: 0;
+    margin: 0 10px;
+  }
   @media screen and (max-width: 479px) {
     width: 100%;
   }
@@ -89,6 +92,10 @@ const MainCommentContainer = css`
     text-align: left;
     font-size: 20px;
     margin-bottom: 10px;
+  }
+  @media screen and (max-width: 767px) {
+    width: 100%;
+    padding: 20px 0;
   }
   @media screen and (max-width: 479px) {
     width: 100%;

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -21,6 +21,12 @@ const MergeContainer = css`
   display: flex;
   @media screen and (max-width: 767px) {
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+  @media screen and (max-width: 479px) {
+    justify-content: center;
+    align-items: center;
   }
 `;
 
@@ -38,16 +44,27 @@ const Container = css`
   align-items: flex-start;
   padding: 10px;
   gap: 20px;
+  @media screen and (max-width: 767px) {
+    margin: 10px 30px;
+  }
+  @media screen and (max-width: 479px) {
+    margin: 10px 30px;
+  }
 `;
 
 const SectionContainer = css`
+  width: fit-content;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  @media screen and (max-width: 479px) {
+    width: 100%;
+  }
 `;
 
 const JamContainer = css`
+  width: fit-content;
   height: fit-content;
   display: flex;
   flex-direction: column;
@@ -55,6 +72,9 @@ const JamContainer = css`
   align-items: center;
   padding: 20px;
   border-radius: 3px;
+  @media screen and (max-width: 479px) {
+    width: 100%;
+  }
 `;
 
 const MainCommentContainer = css`
@@ -62,11 +82,16 @@ const MainCommentContainer = css`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   padding: 20px;
   span {
+    width: 100%;
+    text-align: left;
     font-size: 20px;
     margin-bottom: 10px;
+  }
+  @media screen and (max-width: 479px) {
+    width: 100%;
   }
 `;
 
@@ -79,6 +104,9 @@ const CommentContainer = css`
   align-items: center;
   background-color: ${palette.gray_4};
   border-radius: 3px;
+  @media screen and (max-width: 479px) {
+    width: 100%;
+  }
 `;
 
 const BASE_URL = `${process.env.REACT_APP_URL}`;

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -83,7 +83,7 @@ const CommentContainer = css`
 
 const BASE_URL = `${process.env.REACT_APP_URL}`;
 
-const JamDetail = ({ isEdit, setIsEdit }) => {
+const JamDetail = ({ setIsEdit }) => {
   const [text, setText] = useState('');
   const [comments, setComments] = useState([]);
   const nextId = useRef(0);
@@ -157,9 +157,12 @@ const JamDetail = ({ isEdit, setIsEdit }) => {
           <ThemeProvider theme={palette}>
             <div css={JamContainer}>
               <JamInfo
-                isEdit={isEdit}
                 setIsEdit={setIsEdit}
                 jamData={jamData}
+                isComplete={isComplete}
+                setIsComplete={setIsComplete}
+                joiner={joiner}
+                setJoiner={setJoiner}
               />
             </div>
           </ThemeProvider>

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -21,7 +21,7 @@ import { getCookie } from '../Components/SignComp/Cookie';
 const MergeContainer = css`
   width: 100%;
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: flex-start;
 `;
 
@@ -41,17 +41,23 @@ const Container = css`
   justify-content: center;
   align-items: center;
   padding: 5px;
+  @media screen and (max-width: 767px) {
+    margin: 10px 20px;
+  }
 `;
 
 const Header = css`
-  width: 800px;
-  min-width: 300px;
+  width: 100%;
+  max-width: 790px;
   background-color: white;
   display: flex;
   flex-direction: column;
   justify-content: center;
   margin-bottom: 5px;
   margin-top: 10px;
+  @media screen and (max-width: 767px) {
+    max-width: 650px;
+  }
 `;
 
 const HeaderTap = css`

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -42,7 +42,10 @@ const Container = css`
   align-items: center;
   padding: 5px;
   @media screen and (max-width: 767px) {
-    margin: 10px 20px;
+    margin: 10px 40px;
+  }
+  @media screen and (max-width: 479px) {
+    padding: 0 20px;
   }
 `;
 
@@ -57,6 +60,9 @@ const Header = css`
   margin-top: 10px;
   @media screen and (max-width: 767px) {
     max-width: 650px;
+  }
+  @media screen and (max-width: 479px) {
+    max-width: 460px;
   }
 `;
 
@@ -113,12 +119,28 @@ const Tapstyle = css`
   }
 `;
 
+const FormContainer = css`
+  width: 100%;
+  max-width: 790px;
+  @media screen and (max-width: 479px) {
+    width: 100%;
+    max-width: 460px;
+  }
+`;
+
 const SectionContainer = css`
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  @media screen and (max-width: 479px) {
+    max-width: 460px;
+    flex-wrap: wrap;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+  }
 `;
 
 const ArticleLeft = css`
@@ -129,6 +151,10 @@ const ArticleLeft = css`
   justify-content: space-between;
   align-items: space-between;
   margin-right: 10px;
+  min-width: 300px;
+  @media screen and (max-width: 479px) {
+    margin-right: 0;
+  }
 `;
 
 const ArticleRight = css`
@@ -137,6 +163,10 @@ const ArticleRight = css`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
+  @media screen and (max-width: 479px) {
+    width: 100%;
+    max-width: none;
+  }
 `;
 
 const ChatlinkBox = css`
@@ -380,7 +410,7 @@ const JamMake = ({ isEdit }) => {
             )}
           </div>
         </header>
-        <form id="makeStudy" onSubmit={handleSubmit}>
+        <form id="makeStudy" css={FormContainer} onSubmit={handleSubmit}>
           <main css={SectionContainer}>
             <div css={ArticleLeft}>
               <div>

--- a/client/src/Pages/JamMake.js
+++ b/client/src/Pages/JamMake.js
@@ -23,12 +23,16 @@ const MergeContainer = css`
   display: flex;
   justify-content: center;
   align-items: flex-start;
+  @media screen and (max-width: 767px) {
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 const sidebarContainer = css`
   display: flex;
   @media screen and (max-width: 767px) {
-    display: none;
+    width: 100%;
   }
 `;
 
@@ -42,10 +46,12 @@ const Container = css`
   align-items: center;
   padding: 5px;
   @media screen and (max-width: 767px) {
-    margin: 10px 40px;
+    margin: 10px 20px;
+    width: 95%;
   }
   @media screen and (max-width: 479px) {
-    padding: 0 20px;
+    padding: 0 10px;
+    width: 95%;
   }
 `;
 
@@ -59,7 +65,7 @@ const Header = css`
   margin-bottom: 5px;
   margin-top: 10px;
   @media screen and (max-width: 767px) {
-    max-width: 650px;
+    /* max-width: 650px; */
   }
   @media screen and (max-width: 479px) {
     max-width: 460px;

--- a/client/src/Styles/theme.js
+++ b/client/src/Styles/theme.js
@@ -68,5 +68,13 @@ const theme = createTheme({
       main: '#FFCABB',
     },
   },
+  breakpoints: {
+    values: {
+      mobile: 0,
+      tablet: 767,
+      laptop: 1024,
+      desktop: 1280,
+    },
+  },
 });
 export { palette, themeUserPage, theme };


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 태블릿(breakpoint 767px 이하)과 모바일(breakpoint 479px 이하) 반응형 디자인 적용
- 입력폼 mui 라이브러리는 theme.js 에 breakpoint 설정하여 적용
- 잼 개설페이지 입력폼 반응형 크기 적용, daterangepicker 오픈시 위치 조정, 위치 키워드 검색 모달 반응형 크기 조정 등
- 잼 상세페이지 사이드바 제거 및 추가 컴포넌트를 생성하여 반응형 적용, 캐러셀 반응형 적용, 댓글 부분 반응형 적용
- 반응형 헤더에서 잼 만들기 버튼 보이도록 설정
- 가로형 카테고리 사이드바를 개설페이지와 상세페이지에 연결 적용

## 스크린샷
![image](https://user-images.githubusercontent.com/97942837/208028016-e7a38ab2-5747-439c-aa20-0d141ed0ce37.png)
![image](https://user-images.githubusercontent.com/97942837/208028192-82d957fb-9689-4071-874b-5f42cfedb317.png)
![image](https://user-images.githubusercontent.com/97942837/208028240-9182f71d-8fe0-4ee7-8979-6e2c9dbe9e95.png)
![image](https://user-images.githubusercontent.com/97942837/208028496-fd10ba72-0db2-4359-a765-e8350fdd44b2.png)
![image](https://user-images.githubusercontent.com/97942837/208028553-a4bedfc0-8ffe-424c-a181-32db8749c5de.png)
![image](https://user-images.githubusercontent.com/97942837/208028623-8decebda-3e61-4800-ae8b-b4fbd7464f8e.png)
![image](https://user-images.githubusercontent.com/97942837/208029292-ce48d000-7cc5-4d38-8cfc-c79c9abc3287.png)

## 추가정보
- 현재 rsuite (react suite) daterangepicker 관련 적용 이슈
- 모바일 화면에서 daterangepicker 선택시 가로로 화면이 충분치 않아서 수정이 필요
- 한개 달력으로 선택하는 모드 적용시, ~까지 부분에서 날짜는 설정이 가능하지만 시간부분이 원활하지 않은 걸로 확인됨
- 오픈되는 달력 크기를 조정한다던지 달력의 레이아웃을 가로에서 세로로 바꿔보는 부분을 고려중
(크롬 개발자 도구 css 부분에서 직접 수정해보니 적용이 되는 것으로 보임)
- 라이브러리 내부 속성에 접근해서 수정해야 할 것 같은데 자료를 검색하고 해봐도 계속 적용이 안되서 일단 현재까지 적용한 부분 반영