### PR TITLE
[client] 홈 화면 반응형 디자인 수정

### DIFF
--- a/client/src/Components/FloatingButton.js
+++ b/client/src/Components/FloatingButton.js
@@ -1,0 +1,35 @@
+import { ThemeProvider } from '@mui/material';
+import Fab from '@mui/material/Fab';
+import AddIcon from '@mui/icons-material/Add';
+import { css } from '@emotion/css';
+import { useNavigate } from 'react-router-dom';
+import { theme } from '../Styles/theme';
+
+const floatingIcon = css`
+  display: none;
+  @media screen and (max-width: 767px) {
+    display: flex;
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 1;
+  }
+`;
+
+const FloatingButton = () => {
+  const Navigate = useNavigate();
+  const handleAddClick = () => {
+    Navigate('/jammake');
+  };
+  return (
+    <div className={floatingIcon}>
+      <ThemeProvider theme={theme}>
+        <Fab color="primary" aria-label="add" onClick={handleAddClick}>
+          <AddIcon />
+        </Fab>
+      </ThemeProvider>
+    </div>
+  );
+};
+
+export default FloatingButton;

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -108,9 +108,9 @@ const createJamBtn = css`
     background-color: ${palette.colorAccent};
     color: ${palette.white};
   }
-  /* @media screen and (max-width: 767px) {
+  @media screen and (max-width: 767px) {
     display: none;
-  } */
+  }
 `;
 const username = css`
   margin: 10px;

--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -16,6 +16,7 @@ import { pageNumber, selectedCategory, totalPageNumber } from '../Atom/atoms';
 import ScrollToTop from '../ScrollToTop';
 import { NoCategoryData } from '../Components/NoData';
 import JamPagination from '../Components/Card/JamPagination';
+import FloatingButton from '../Components/FloatingButton';
 
 const pagewithSidebar = css`
   display: flex;
@@ -122,6 +123,7 @@ const Category = () => {
   return (
     <div className={pagewithSidebar}>
       <Sidebar />
+      <FloatingButton />
       <ScrollToTop />
       <div className={category}>
         <div className={topContainer}>

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -3,7 +3,6 @@
 /* eslint-disable react/prop-types */
 import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
-// import palette from '../Styles/theme';
 import { useRecoilState } from 'recoil';
 import Sidebar from '../Components/Sidebar';
 import LongJamCard from '../Components/Card/LongJamCard';
@@ -11,6 +10,7 @@ import Map from '../Components/Map/Map';
 import { location, coordinate } from '../Atom/atoms';
 import { fetchJamRead } from '../Utils/fetchJam';
 import { NoNearyByData } from '../Components/NoData';
+import FloatingButton from '../Components/FloatingButton';
 
 const pagewithSidebar = css`
   display: flex;
@@ -79,6 +79,7 @@ const Home = () => {
   return (
     <div className={pagewithSidebar}>
       <Sidebar />
+      <FloatingButton />
       <div className={home}>
         <h1>
           {currentLocation

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -26,6 +26,13 @@ const home = css`
   h1 {
     margin: 10px;
   }
+  @media screen and (max-width: 767px) {
+    margin: 0px;
+    padding: 0px;
+    h1 {
+      display: none;
+    }
+  }
 `;
 
 const mainArea = css`
@@ -33,6 +40,7 @@ const mainArea = css`
   margin: 10px;
   @media screen and (max-width: 767px) {
     flex-direction: column;
+    margin: 0px;
   }
 `;
 


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 모바일버전의 홈 화면의 지도 여백을 삭제했습니다.
- 모바일버전의 홈 화면에서 동네 이름 텍스트를 삭제했습니다.
    - 헤더의 중간으로 옮길 예정입니다.
- 모바일버전의 홈, categoryResult 페이지에서 헤더에 있던 잼만들기 버튼을 삭제하고 우측하단의 floating 버튼으로 변경했습니다.


## 스크린샷
![image](https://user-images.githubusercontent.com/53070295/208045908-2614273c-a3ed-4b14-8c50-aa8504220acd.png)

