### PR TITLE
[client] 헤더 drawer 추가

### DIFF
--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -46,10 +46,14 @@ const addressBtn = css`
 `;
 
 export default function AddressDialog() {
+  const [currentLocation, setCurrentLocation] = useRecoilState(location);
+  const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
+  const [currentWidth, setCurrentWidth] = useState(1024);
+
   const [open, setOpen] = useState(false);
-  const [city, setCity] = useState('');
-  const [gu, setGu] = useState('');
-  const [dong, setDong] = useState('');
+  const [city, setCity] = useState(currentLocation.split(' ')[0]);
+  const [gu, setGu] = useState(currentLocation.split(' ')[1]);
+  const [dong, setDong] = useState(currentLocation.split(' ')[2]);
 
   const [cityList, setCityList] = useState([]);
   const [guList, setGuList] = useState([]);
@@ -116,9 +120,6 @@ export default function AddressDialog() {
     setOpen(false);
   };
 
-  const [currentLocation, setCurrentLocation] = useRecoilState(location);
-  const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
-  const [currentWidth, setCurrentWidth] = useState(1024);
   const onSubmit = () => {
     setCurrentLocation(`${city} ${gu} ${dong}`);
     setIsUserLocationChanged(true);
@@ -131,6 +132,7 @@ export default function AddressDialog() {
 
   useEffect(() => {
     setCurrentWidth(window.innerWidth);
+    setCurrentLocation(`${city} ${gu} ${dong}`);
   }, [window.innerWidth]);
   return (
     <div className={addressContainer}>

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -67,14 +67,18 @@ export default function AddressDialog() {
     const code = cityCode.slice(0, 2).concat('*00000');
     const apiLocation = getJuso(code);
     apiLocation.then(data => {
-      setGuList(data.regcodes.slice(1));
+      setGuList(
+        data.regcodes.slice(1).sort((a, b) => a.name.localeCompare(b.name)),
+      );
     });
   }
   function getDongData(guCode) {
     const code = guCode.slice(0, 5).concat('*&is_ignore_zero=true');
     const apiLocation = getJuso(code);
     apiLocation.then(data => {
-      setDongList(data.regcodes);
+      setDongList(
+        data.regcodes.slice(1).sort((a, b) => a.name.localeCompare(b.name)),
+      );
     });
   }
 

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -46,14 +46,10 @@ const addressBtn = css`
 `;
 
 export default function AddressDialog() {
-  const [currentLocation, setCurrentLocation] = useRecoilState(location);
-  const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
-  const [currentWidth, setCurrentWidth] = useState(1024);
-
   const [open, setOpen] = useState(false);
-  const [city, setCity] = useState(currentLocation.split(' ')[0]);
-  const [gu, setGu] = useState(currentLocation.split(' ')[1]);
-  const [dong, setDong] = useState(currentLocation.split(' ')[2]);
+  const [city, setCity] = useState('');
+  const [gu, setGu] = useState('');
+  const [dong, setDong] = useState('');
 
   const [cityList, setCityList] = useState([]);
   const [guList, setGuList] = useState([]);
@@ -120,6 +116,9 @@ export default function AddressDialog() {
     setOpen(false);
   };
 
+  const [currentLocation, setCurrentLocation] = useRecoilState(location);
+  const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
+  const [currentWidth, setCurrentWidth] = useState(1024);
   const onSubmit = () => {
     setCurrentLocation(`${city} ${gu} ${dong}`);
     setIsUserLocationChanged(true);
@@ -132,7 +131,6 @@ export default function AddressDialog() {
 
   useEffect(() => {
     setCurrentWidth(window.innerWidth);
-    setCurrentLocation(`${city} ${gu} ${dong}`);
   }, [window.innerWidth]);
   return (
     <div className={addressContainer}>

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -41,6 +41,7 @@ const addressBtn = css`
     margin: 0px;
     padding: 0px;
     background-color: transparent;
+    font-weight: bold;
   }
 `;
 
@@ -115,9 +116,9 @@ export default function AddressDialog() {
     setOpen(false);
   };
 
-  const [, setCurrentLocation] = useRecoilState(location);
+  const [currentLocation, setCurrentLocation] = useRecoilState(location);
   const [, setIsUserLocationChanged] = useRecoilState(locationChanged);
-
+  const [currentWidth, setCurrentWidth] = useState(1024);
   const onSubmit = () => {
     setCurrentLocation(`${city} ${gu} ${dong}`);
     setIsUserLocationChanged(true);
@@ -128,10 +129,13 @@ export default function AddressDialog() {
     getCityData('*00000000');
   }, []);
 
+  useEffect(() => {
+    setCurrentWidth(window.innerWidth);
+  }, [window.innerWidth]);
   return (
     <div className={addressContainer}>
       <button className={addressBtn} onClick={handleClickOpen} type="button">
-        동네 선택
+        {currentWidth > 767 ? '동네선택' : currentLocation} ▾
       </button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>동네를 선택해주세요!</DialogTitle>

--- a/client/src/Components/Header/AddressDialog.js
+++ b/client/src/Components/Header/AddressDialog.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { css } from '@emotion/css';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -23,11 +22,11 @@ const addressContainer = css`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 5px 10px;
+  margin: 0px 10px;
   padding: 20px;
   white-space: nowrap;
   @media screen and (max-width: 767px) {
-    margin: 0px;
+    margin: 10px 0px;
     padding: 0px;
   }
 `;
@@ -46,10 +45,10 @@ const addressBtn = css`
 `;
 
 export default function AddressDialog() {
-  const [open, setOpen] = React.useState(false);
-  const [city, setCity] = React.useState('');
-  const [gu, setGu] = React.useState('');
-  const [dong, setDong] = React.useState('');
+  const [open, setOpen] = useState(false);
+  const [city, setCity] = useState('');
+  const [gu, setGu] = useState('');
+  const [dong, setDong] = useState('');
 
   const [cityList, setCityList] = useState([]);
   const [guList, setGuList] = useState([]);
@@ -132,7 +131,7 @@ export default function AddressDialog() {
   return (
     <div className={addressContainer}>
       <button className={addressBtn} onClick={handleClickOpen} type="button">
-        동네 선택 ▾
+        동네 선택
       </button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>동네를 선택해주세요!</DialogTitle>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -160,6 +160,12 @@ const drawerContainer = css`
   }
 `;
 
+const AddressDialogContainer = css`
+  @media screen and (max-width: 767px) {
+    display: none;
+  }
+`;
+
 const BackBtn = () => {
   const navigate = useNavigate();
   const handleBackBtnClick = () => {
@@ -173,7 +179,13 @@ const BackBtn = () => {
     </div>
   );
 };
-
+const CityBtn = () => {
+  return (
+    <div className={AddressDialogContainer}>
+      <AddressDialog />
+    </div>
+  );
+};
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
@@ -185,6 +197,7 @@ const SearchBar = () => {
     sessionStorage.setItem('searchText', searchText);
     navigate('/category');
   };
+
   return (
     <form className={searchBar} onSubmit={handleSubmit}>
       <Search>
@@ -255,8 +268,8 @@ const Header = () => {
         <Link to="/" onClick={() => sessionStorage.clear}>
           <img className={logo} alt="logo_jamit" src={logoImage} />
         </Link>
-        <BackBtn className={backBtn} />
-        <AddressDialog />
+        <BackBtn />
+        <CityBtn />
         <SearchBar />
         {!isLogin ? <LoginArea /> : <LogoutArea />}
         <Drawer />

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { Avatar } from '@mui/material/';
 import { MdArrowBackIosNew } from 'react-icons/md';
 import { IconButton } from '@material-ui/core';
+import { BiSearch } from 'react-icons/bi';
 import { palette } from '../../Styles/theme';
 import logoImage from '../../Assets/images/logo_header.png';
 import AddressDialog from './AddressDialog';
@@ -31,7 +32,7 @@ const header = css`
   position: fixed;
   z-index: 10;
   @media screen and (max-width: 767px) {
-    padding: 10px;
+    padding: 0px;
     height: 70px;
   }
 `;
@@ -62,10 +63,7 @@ const searchBar = css`
   margin: 15px 10px;
   flex-grow: 1;
   @media screen and (max-width: 767px) {
-    padding: 10px 0px;
-    margin: 0px 10px;
-    background-color: transparent;
-    border: 1px solid ${palette.gray_4};
+    display: none;
   }
 `;
 
@@ -93,8 +91,8 @@ const avataBtn = css`
   display: none;
   cursor: pointer;
   @media screen and (max-width: 767px) {
-    display: inline;
-    cursor: pointer;
+    //TODO: display:none -> inline 으로 변경 후 코드를 작성해주세요
+    display: none;
   }
 `;
 
@@ -152,6 +150,14 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   },
 }));
 
+const SearchContainer = css`
+  display: none;
+  @media screen and (max-width: 767px) {
+    display: flex;
+    height: 100%;
+  }
+`;
+
 const drawerContainer = css`
   display: none;
   @media screen and (max-width: 767px) {
@@ -162,7 +168,9 @@ const drawerContainer = css`
 
 const AddressDialogContainer = css`
   @media screen and (max-width: 767px) {
-    display: none;
+    display: flex;
+    justify-content: center;
+    flex-grow: 1;
   }
 `;
 
@@ -176,6 +184,9 @@ const BackBtn = () => {
       <IconButton aria-label="back" onClick={handleBackBtnClick}>
         <MdArrowBackIosNew fontSize="large" />
       </IconButton>
+      <IconButton>
+        <MdArrowBackIosNew fontSize="large" visibility="hidden" />
+      </IconButton>
     </div>
   );
 };
@@ -186,6 +197,17 @@ const CityBtn = () => {
     </div>
   );
 };
+
+const SearchBtn = () => {
+  return (
+    <div className={SearchContainer}>
+      <IconButton aria-label="search">
+        <BiSearch />
+      </IconButton>
+    </div>
+  );
+};
+
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
@@ -271,6 +293,7 @@ const Header = () => {
         <BackBtn />
         <CityBtn />
         <SearchBar />
+        <SearchBtn />
         {!isLogin ? <LoginArea /> : <LogoutArea />}
         <Drawer />
       </div>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -6,13 +6,14 @@ import { useRecoilState } from 'recoil';
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { Avatar } from '@mui/material/';
-import { MdArrowBack } from 'react-icons/md';
+import { MdArrowBackIosNew } from 'react-icons/md';
 import { IconButton } from '@material-ui/core';
 import { palette } from '../../Styles/theme';
 import logoImage from '../../Assets/images/logo_header.png';
 import AddressDialog from './AddressDialog';
 import AccountMenu from './AccountMenu';
 import { isLoginState, loginUserInfoState } from '../../Atom/atoms';
+import MenuDrawer from './MenuDrawer';
 
 const headerBox = css`
   height: 100px;
@@ -151,6 +152,14 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
   },
 }));
 
+const drawerContainer = css`
+  display: none;
+  @media screen and (max-width: 767px) {
+    display: flex;
+    height: 100%;
+  }
+`;
+
 const BackBtn = () => {
   const navigate = useNavigate();
   const handleBackBtnClick = () => {
@@ -159,7 +168,7 @@ const BackBtn = () => {
   return (
     <div className={backBtn}>
       <IconButton aria-label="back" onClick={handleBackBtnClick}>
-        <MdArrowBack fontSize="large" />
+        <MdArrowBackIosNew fontSize="large" />
       </IconButton>
     </div>
   );
@@ -228,6 +237,16 @@ const LogoutArea = () => {
   );
 };
 
+const Drawer = () => {
+  return (
+    <div className={drawerContainer}>
+      <IconButton aria-label="back">
+        <MenuDrawer fontSize="large" />
+      </IconButton>
+    </div>
+  );
+};
+
 const Header = () => {
   const [isLogin] = useRecoilState(isLoginState);
   return (
@@ -240,6 +259,7 @@ const Header = () => {
         <AddressDialog />
         <SearchBar />
         {!isLogin ? <LoginArea /> : <LogoutArea />}
+        <Drawer />
       </div>
     </div>
   );

--- a/client/src/Components/Header/MenuDrawer.js
+++ b/client/src/Components/Header/MenuDrawer.js
@@ -9,6 +9,7 @@ import { MdMenu } from 'react-icons/md';
 import { css } from '@emotion/css';
 import { Avatar } from '@mui/material/';
 import { useNavigate } from 'react-router-dom';
+import AddressDialog from './AddressDialog';
 
 const drawerContainer = css`
   width: 250px;
@@ -29,6 +30,7 @@ const MenuDrawer = () => {
     navigate(path);
     setIsOpen(false);
   };
+
   return (
     <div>
       <MdMenu aria-label="open drawer" onClick={() => setIsOpen(true)} />
@@ -68,8 +70,8 @@ const MenuDrawer = () => {
           </List>
           <Divider />
           <List>
-            <ListItem button>
-              <ListItemText primary="동네 선택" />
+            <ListItem button onClick={() => setIsOpen(false)}>
+              <AddressDialog />
             </ListItem>
           </List>
           <Divider />

--- a/client/src/Components/Header/MenuDrawer.js
+++ b/client/src/Components/Header/MenuDrawer.js
@@ -1,4 +1,3 @@
-import Box from '@mui/material/Box';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import List from '@mui/material/List';
 import Divider from '@mui/material/Divider';
@@ -9,16 +8,28 @@ import { MdMenu } from 'react-icons/md';
 import { css } from '@emotion/css';
 import { Avatar } from '@mui/material/';
 import { useNavigate } from 'react-router-dom';
-import AddressDialog from './AddressDialog';
 
 const drawerContainer = css`
   width: 250px;
+`;
+
+const userContainer = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 20px;
+
+  p {
+    font-weight: bold;
+    margin: 10px;
+  }
 `;
 const avataBtn = css`
   display: flex;
   justify-content: center;
   cursor: pointer;
-  margin-bottom: 10px;
+  margin: 10px;
 `;
 const MenuDrawer = () => {
   const navigate = useNavigate();
@@ -41,12 +52,12 @@ const MenuDrawer = () => {
         onOpen={() => {}}
       >
         <div className={drawerContainer}>
-          <Box textAlign="center" p={2}>
+          <div className={userContainer}>
             <div className={avataBtn}>
               <Avatar sx={{ width: 70, height: 70 }} />
             </div>
-            유저이름님
-          </Box>
+            <p>유저이름님</p>
+          </div>
           <Divider />
           {/* //TODO: 로그인 여부에 따라 아래 두가지 리스트 중 하나만 보이도록 하기 */}
           <List>
@@ -66,12 +77,6 @@ const MenuDrawer = () => {
             </ListItem>
             <ListItem button>
               <ListItemText primary="회원가입" />
-            </ListItem>
-          </List>
-          <Divider />
-          <List>
-            <ListItem button onClick={() => setIsOpen(false)}>
-              <AddressDialog />
             </ListItem>
           </List>
           <Divider />

--- a/client/src/Components/Header/MenuDrawer.js
+++ b/client/src/Components/Header/MenuDrawer.js
@@ -1,0 +1,89 @@
+import Box from '@mui/material/Box';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import List from '@mui/material/List';
+import Divider from '@mui/material/Divider';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import { useState } from 'react';
+import { MdMenu } from 'react-icons/md';
+import { css } from '@emotion/css';
+import { Avatar } from '@mui/material/';
+import { useNavigate } from 'react-router-dom';
+
+const drawerContainer = css`
+  width: 250px;
+`;
+const avataBtn = css`
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+  margin-bottom: 10px;
+`;
+const MenuDrawer = () => {
+  const navigate = useNavigate();
+
+  const [isOpen, setIsOpen] = useState(false);
+  // isLogin 필요
+
+  const MoveTo = path => {
+    navigate(path);
+    setIsOpen(false);
+  };
+  return (
+    <div>
+      <MdMenu aria-label="open drawer" onClick={() => setIsOpen(true)} />
+      <SwipeableDrawer
+        anchor="right"
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        onOpen={() => {}}
+      >
+        <div className={drawerContainer}>
+          <Box textAlign="center" p={2}>
+            <div className={avataBtn}>
+              <Avatar sx={{ width: 70, height: 70 }} />
+            </div>
+            유저이름님
+          </Box>
+          <Divider />
+          {/* //TODO: 로그인 여부에 따라 아래 두가지 리스트 중 하나만 보이도록 하기 */}
+          <List>
+            <ListItem button>
+              <ListItemText primary="마이페이지" />
+            </ListItem>
+            <ListItem button>
+              <ListItemText primary="프로필 수정" />
+            </ListItem>
+            <ListItem button>
+              <ListItemText primary="로그아웃" />
+            </ListItem>
+          </List>
+          <List>
+            <ListItem button>
+              <ListItemText primary="로그인" />
+            </ListItem>
+            <ListItem button>
+              <ListItemText primary="회원가입" />
+            </ListItem>
+          </List>
+          <Divider />
+          <List>
+            <ListItem button>
+              <ListItemText primary="동네 선택" />
+            </ListItem>
+          </List>
+          <Divider />
+          <List>
+            <ListItem button>
+              <ListItemText primary="잼잇 소개" onClick={() => MoveTo('/')} />
+            </ListItem>
+            <ListItem button>
+              <ListItemText primary="문의" />
+            </ListItem>
+          </List>
+        </div>
+      </SwipeableDrawer>
+    </div>
+  );
+};
+export default MenuDrawer;

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -109,9 +109,7 @@ const Map = ({ jamData }) => {
         yAnchor: 1,
       });
 
-      kakao.maps.event.addListener(marker, 'mouseover', function () {
-        overlay.setMap(map);
-      });
+      overlay.setMap(map);
 
       kakao.maps.event.addListener(marker, 'click', function () {
         navigate(`/jamdetail/${mapPoints[i].jamId}`);

--- a/client/src/Components/Map/Map.js
+++ b/client/src/Components/Map/Map.js
@@ -8,13 +8,13 @@ import { location, coordinate, locationChanged } from '../../Atom/atoms';
 
 const { kakao } = window;
 const Map = ({ jamData }) => {
-  const [latitude, setLatitude] = useState(37.5602098);
-  const [longitude, setLongitude] = useState(126.825479);
   const [currentLevel, setCurrentLevel] = useState(4);
   const [currentLocation, setCurrentLocation] = useRecoilState(location);
-  const [, setCurrentCoordinate] = useRecoilState(coordinate);
+  const [currentCoordinate, setCurrentCoordinate] = useRecoilState(coordinate);
   const [isUserLocationChanged, setIsUserLocationChanged] =
     useRecoilState(locationChanged);
+  const [latitude, setLatitude] = useState(currentCoordinate.latitude);
+  const [longitude, setLongitude] = useState(currentCoordinate.longitude);
   const navigate = useNavigate();
   function getMap() {
     const container = document.getElementById('map');


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용

- 모바일 버전의 헤더에 drawer를 생성해 유저정보, 유저메뉴, 서비스 소개 기능을 추가했습니다.
- 동네검색 버튼 텍스트를 현재 동네로 수정했습니다.
- 동네검색 내 2, 3단계 동네를 가나다순으로 정렬했습니다.
- 검색창을 검색 버튼으로 변경했습니다.

## 스크린샷
|![image](https://user-images.githubusercontent.com/53070295/208302119-a3433e05-6b41-4258-acf3-d87336606b03.png)|![image](https://user-images.githubusercontent.com/53070295/208301760-d56b5205-aca4-4c73-ae3c-832caf790e99.png)|
|:---:|:---:|



![image](https://user-images.githubusercontent.com/53070295/208301687-bd50938f-f039-4d46-aa93-211fd9d6df6f.png)
