### PR TITLE
[client] 모바일용 검색페이지 제작

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import JamDetail from './Pages/JamDetail';
 import JamMake from './Pages/JamMake';
 import PageNotFound from './Pages/NotFound';
 import Landing from './Pages/Landing';
+import Search from './Pages/Search';
 
 function App() {
   const [isEdit, setIsEdit] = useState(false);
@@ -23,6 +24,7 @@ function App() {
           <Route path="/" element={<Landing />} />
           <Route path="/home" element={<Home />} />
           <Route path="/category" element={<Category />} />
+          <Route path="/search" element={<Search />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/mypage/*" element={<Mypage />} />

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -88,6 +88,7 @@ const loginBtn = css`
 `;
 
 const avataBtn = css`
+  display: none;
   cursor: pointer;
   @media screen and (max-width: 767px) {
     display: none;

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import SearchIcon from '@mui/icons-material/Search';
 import InputBase from '@mui/material/InputBase';
 import { useRecoilState } from 'recoil';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useState } from 'react';
 import { Avatar } from '@mui/material/';
 import { MdArrowBackIosNew } from 'react-icons/md';
@@ -199,9 +199,13 @@ const CityBtn = () => {
 };
 
 const SearchBtn = () => {
+  const navigate = useNavigate();
+  const handleSearchBtnClick = () => {
+    navigate('/search');
+  };
   return (
     <div className={SearchContainer}>
-      <IconButton aria-label="search">
+      <IconButton aria-label="search" onClick={handleSearchBtnClick}>
         <BiSearch />
       </IconButton>
     </div>
@@ -284,6 +288,8 @@ const Drawer = () => {
 
 const Header = () => {
   const [isLogin] = useRecoilState(isLoginState);
+  const locationNow = useLocation();
+  if (locationNow.pathname === '/search') return null;
   return (
     <div className={headerBox}>
       <div className={header}>

--- a/client/src/Components/Header/Header.js
+++ b/client/src/Components/Header/Header.js
@@ -88,10 +88,8 @@ const loginBtn = css`
 `;
 
 const avataBtn = css`
-  display: none;
   cursor: pointer;
   @media screen and (max-width: 767px) {
-    //TODO: display:none -> inline 으로 변경 후 코드를 작성해주세요
     display: none;
   }
 `;

--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -46,7 +46,12 @@ const topContainer = css`
     justify-content: end;
   }
 `;
-
+const searchTextResult = css`
+  padding: 0px 50px;
+  span {
+    font-weight: bold;
+  }
+`;
 const cardContainer = css`
   display: flex;
   flex-flow: row wrap;
@@ -142,6 +147,9 @@ const Category = () => {
               })}
             </ButtonGroup>
           </ThemeProvider>
+        </div>
+        <div className={searchTextResult}>
+          <span>{searchText}</span> 검색 결과입니다.
         </div>
         {filteredData.length ? (
           <div className={cardContainer}>

--- a/client/src/Pages/Home.js
+++ b/client/src/Pages/Home.js
@@ -57,7 +57,7 @@ const map = css`
   }
 `;
 
-const list = css`
+export const list = css`
   display: flex;
   flex-direction: column;
   height: 70vh;

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -1,0 +1,111 @@
+import { css } from '@emotion/css';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { BiSearch } from 'react-icons/bi';
+import { styled } from '@mui/material/styles';
+import InputBase from '@mui/material/InputBase';
+import { IconButton } from '@material-ui/core';
+import { MdArrowBackIosNew } from 'react-icons/md';
+import { palette } from '../Styles/theme';
+
+const SearchContainer = styled('div')(({ theme }) => ({
+  position: 'relative',
+  width: '100%',
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: (theme.palette.common.white, 0.15),
+  '&:hover': {
+    backgroundColor: (theme.palette.common.white, 0.25),
+  },
+  marginRight: theme.spacing(2),
+}));
+
+const SearchIconWrapper = styled('div')(({ theme }) => ({
+  padding: theme.spacing(0, 1),
+  height: '100%',
+  position: 'absolute',
+  pointerEvents: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}));
+
+const StyledInputBase = styled(InputBase)(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  '& .MuiInputBase-input': {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+    transition: theme.transitions.create('width'),
+    width: '100%',
+  },
+}));
+
+const container = css`
+  display: flex;
+`;
+
+const searchBar = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${palette.gray_4};
+  border-radius: 10px;
+  padding: 5px;
+  margin: 10px;
+  margin-right: 20px;
+  flex-grow: 1;
+`;
+const SearchBar = () => {
+  const navigate = useNavigate();
+  const [searchText, setSearchText] = useState('');
+  const handleSearch = e => {
+    setSearchText(e.target.value);
+  };
+
+  const handleSubmit = () => {
+    sessionStorage.setItem('searchText', searchText);
+    navigate('/category');
+  };
+
+  return (
+    <form className={searchBar} onSubmit={handleSubmit}>
+      <SearchContainer>
+        <SearchIconWrapper>
+          <BiSearch />
+        </SearchIconWrapper>
+        <StyledInputBase
+          onChange={handleSearch}
+          placeholder="제목이나 내용으로 검색해보세요!"
+          inputProps={{ 'aria-label': 'search' }}
+          onClick={() => sessionStorage.clear()}
+        />
+      </SearchContainer>
+    </form>
+  );
+};
+const backBtn = css`
+  display: flex;
+`;
+const BackBtn = () => {
+  const navigate = useNavigate();
+  const handleBackBtnClick = () => {
+    navigate(-1);
+  };
+  return (
+    <div className={backBtn}>
+      <IconButton aria-label="back" onClick={handleBackBtnClick}>
+        <MdArrowBackIosNew fontSize="large" />
+      </IconButton>
+    </div>
+  );
+};
+const Search = () => {
+  return (
+    <nav className={container}>
+      <BackBtn />
+      <SearchBar />
+    </nav>
+  );
+};
+
+export default Search;

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -1,12 +1,16 @@
 import { css } from '@emotion/css';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { BiSearch } from 'react-icons/bi';
 import { styled } from '@mui/material/styles';
 import InputBase from '@mui/material/InputBase';
 import { IconButton } from '@material-ui/core';
 import { MdArrowBackIosNew } from 'react-icons/md';
 import { palette } from '../Styles/theme';
+import LongJamCard from '../Components/Card/LongJamCard';
+import { fetchJamRead } from '../Utils/fetchJam';
+import { NoNearyByData } from '../Components/NoData';
+import { list } from './Home';
 
 const SearchContainer = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -55,9 +59,19 @@ const searchBar = css`
   margin-right: 20px;
   flex-grow: 1;
 `;
+
+const jamList = css`
+  margin: 10px;
+`;
+
+const label = css`
+  margin: 20px;
+  font-weight: bold;
+`;
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
+
   const handleSearch = e => {
     setSearchText(e.target.value);
   };
@@ -101,11 +115,40 @@ const BackBtn = () => {
   );
 };
 const Search = () => {
+  const [jamData, setJamData] = useState([]);
+  useEffect(() => {
+    const endpoint = `/jams`;
+    const locateJams = fetchJamRead(endpoint);
+    locateJams.then(data => {
+      setJamData(
+        data.content
+          .filter(el => el.completeStatus === 'FALSE')
+          .sort((a, b) => a.jamTo.localeCompare(b.jamTo)),
+      );
+    });
+  }, []);
   return (
-    <nav className={container}>
-      <BackBtn />
-      <SearchBar />
-    </nav>
+    <div>
+      <nav className={container}>
+        <BackBtn />
+        <SearchBar />
+      </nav>
+      <p className={label}>마감이 가까운 잼이에요</p>
+      <div className={jamList}>
+        {jamData ? (
+          <div className={list}>
+            {jamData &&
+              jamData.map(jam => {
+                return <LongJamCard key={jam.jamId} jam={jam} />;
+              })}
+          </div>
+        ) : (
+          <div className={list}>
+            <NoNearyByData />
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -78,6 +78,7 @@ const SearchBar = () => {
           placeholder="제목이나 내용으로 검색해보세요!"
           inputProps={{ 'aria-label': 'search' }}
           onClick={() => sessionStorage.clear()}
+          autoFocus
         />
       </SearchContainer>
     </form>


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용

-  헤더의 검색 아이콘 클릭시 검색 페이지로 이동하는 기능을 추가했습니다.
-  검색 페이지 이동시 키패드가 자동으로 보이는 기능을 추가했습니다.
-  검색한 키워드를 확인할 수 있는 텍스트를 추가했습니다.
-  검색 창 하단에는 전체 잼 중 모집중인 잼만 마감날짜 기준으로 오름차순하여 보여주는 기능을 추가했습니다.

## 스크린샷

![image](https://user-images.githubusercontent.com/53070295/208564590-3752e14f-accf-4f4b-ba41-e1f93c98a463.png)


