### PR TITLE
[client] 검색어가 없을때 '검색 결과입니다' 텍스트 보이지 않도록 수정

### DIFF
--- a/client/src/Pages/CategoryResult.js
+++ b/client/src/Pages/CategoryResult.js
@@ -148,9 +148,12 @@ const Category = () => {
             </ButtonGroup>
           </ThemeProvider>
         </div>
-        <div className={searchTextResult}>
-          <span>{searchText}</span> 검색 결과입니다.
-        </div>
+        {searchText && (
+          <div className={searchTextResult}>
+            <span>{searchText}</span> 검색 결과입니다.
+          </div>
+        )}
+
         {filteredData.length ? (
           <div className={cardContainer}>
             {filteredData &&


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 검색하지 않고 전체 잼을 확인 할 때에도 '검색 결과입니다.' 텍스트가 남아있던 오류를 수정했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/53070295/208568078-50004c78-b02d-4a2e-a8c6-c90fb33fa3bb.png)
![image](https://user-images.githubusercontent.com/53070295/208568105-730241a7-8cfb-4d14-b7c5-56ef13e63731.png)


