### PR TITLE
[client] 잼 개설페이지, 상세페이지 반응형 추가 작업 및 수정

### DIFF
--- a/client/src/Components/jamCreateComponent/KakaoMap.js
+++ b/client/src/Components/jamCreateComponent/KakaoMap.js
@@ -15,8 +15,8 @@ const mapContainer = css`
     width: 520px;
   }
   @media screen and (max-width: 479px) {
-    width: 400px;
-    height: 600px;
+    width: 350px;
+    height: 450px;
   }
 `;
 
@@ -42,7 +42,7 @@ const resultList = css`
   }
   @media screen and (max-width: 479px) {
     width: 250px;
-    height: 300px;
+    height: 250px;
     top: 75px;
   }
 

--- a/client/src/Components/jamCreateComponent/KewordAddressModal.js
+++ b/client/src/Components/jamCreateComponent/KewordAddressModal.js
@@ -34,12 +34,12 @@ const KewordAddressModal = ({
 }) => {
   return (
     <div>
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-      >
-        <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+        >
           <Box sx={style}>
             <Typography id="modal-modal-title" variant="h6" component="h2">
               스터디할 장소를 키워드로 입력해보세요
@@ -52,8 +52,8 @@ const KewordAddressModal = ({
               setAddress={setAddress}
             />
           </Box>
-        </ThemeProvider>
-      </Modal>
+        </Modal>
+      </ThemeProvider>
     </div>
   );
 };

--- a/client/src/Components/jamCreateComponent/StudyInputField.js
+++ b/client/src/Components/jamCreateComponent/StudyInputField.js
@@ -8,6 +8,7 @@ import { DateRangePicker } from 'rsuite';
 import KewordAddressModal from './KewordAddressModal';
 import { theme } from '../../Styles/theme';
 // import 'rsuite/dist/rsuite-rtl.css';
+import '../../Styles/pickerStyles.css';
 
 const Container = css`
   width: 100%;
@@ -18,21 +19,6 @@ const Container = css`
   }
   @media screen and (max-width: 479px) {
     max-width: none;
-  }
-  * {
-    .rs-picker
-      .rs-picker-menu
-      .rs-picker-daterange
-      .rs-picker-daterange-menu
-      .rs-picker-daterange-panel
-      .rs-stack
-      .rs-stack-item
-      .rs-picker-daterange-content
-      .rs-picker-daterange-calendar-group {
-      display: flex;
-      flex-direction: column;
-      height: auto;
-    }
   }
 `;
 
@@ -242,11 +228,8 @@ const StudyInputField = ({
               <DateRangePicker
                 format="yyyy-MM-dd hh:mm aa"
                 placement="bottomEnd"
-                // placement="topEnd"
-                // showOneCalendar="true"
                 preventOverflow
                 showMeridian
-                style={{ color: 'black' }}
                 name="period"
                 value={period}
                 onChange={handlePeriodChange}

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -46,6 +46,7 @@ const TitleContainer = css`
     /* justify-content: flex-start; */
     align-items: flex-start;
     gap: 10px;
+    margin-bottom: 5px;
   }
 `;
 

--- a/client/src/Components/jamDetailComponent/JamInfo.js
+++ b/client/src/Components/jamDetailComponent/JamInfo.js
@@ -82,6 +82,7 @@ const MediaButton = css`
 const InfoIcons = css`
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
   font-size: 12px;

--- a/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
+++ b/client/src/Components/jamDetailComponent/JamSideBarStateMedia.js
@@ -7,7 +7,7 @@ import { css } from '@emotion/react';
 import RecruitState from './RecruitState';
 
 const JamSideContainer = css`
-  width: 70px;
+  min-width: 80px;
   height: 100%;
   background-color: #fff;
   font-size: 12px;

--- a/client/src/Components/jamDetailComponent/RecruitState.js
+++ b/client/src/Components/jamDetailComponent/RecruitState.js
@@ -21,6 +21,7 @@ const RecruitState = ({ children, state = 'open' }) => {
         fontSize: '12px',
         textAlign: 'center',
         padding: '3px 12px',
+        minWidth: 'fit-content',
       }}
     >
       {children}

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -15,6 +15,7 @@ import Sidebar from '../Components/Sidebar';
 import { palette } from '../Styles/theme';
 import { getCookie } from '../Components/SignComp/Cookie';
 import Reply from '../Components/jamDetailComponent/Reply';
+import ScrollToTop from '../ScrollToTop';
 
 const MergeContainer = css`
   width: 100%;
@@ -128,6 +129,8 @@ const JamDetail = ({ setIsEdit }) => {
   const { id } = useParams();
 
   const [replyData, setReplyData] = useState([]);
+
+  ScrollToTop();
 
   // eslint-disable-next-line no-shadow
   const getJamData = async () => {

--- a/client/src/Styles/pickerStyles.css
+++ b/client/src/Styles/pickerStyles.css
@@ -1,0 +1,36 @@
+@media screen and (max-width: 479px) {
+  .rs-picker-daterange-menu {
+    /* max-width: 320px; */
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .rs-picker-daterange-panel {
+    /* max-width: 320px; */
+    /* width: 100%; */
+    text-align: center;
+  }
+  .rs-stack-item {
+    width: fit-content;
+  }
+  .rs-picker-daterange-content {
+    width: 100%;
+  }
+  .rs-picker-daterange-header {
+    width: 100%;
+  }
+  .rs-calendar-header-title {
+    font-weight: bold;
+  }
+
+  .rs-picker-daterange-calendar-group {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-width: auto;
+  }
+  .rs-picker-toolbar {
+    margin-bottom: 20px;
+  }
+}

--- a/client/src/Styles/pickerStyles.css
+++ b/client/src/Styles/pickerStyles.css
@@ -1,14 +1,11 @@
 @media screen and (max-width: 479px) {
   .rs-picker-daterange-menu {
-    /* max-width: 320px; */
     width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
   }
   .rs-picker-daterange-panel {
-    /* max-width: 320px; */
-    /* width: 100%; */
     text-align: center;
   }
   .rs-stack-item {
@@ -29,8 +26,5 @@
     display: flex;
     flex-direction: column;
     min-width: auto;
-  }
-  .rs-picker-toolbar {
-    margin-bottom: 20px;
   }
 }


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- rsuite 라이브러리 daterangepicker(날짜 피킹 달력)에서 제공하는 기본 가로모드를  모바일 반응형에서 세로로 적용되도록 구현
- 잼 상세페이지 진입시 페이지 중간부터 보여지는 것 확인후 상단부터 볼 수 있도록 스크롤투탑 적용
- 모바일모드에서 키워드 검색 모달 좌우가 잘리는 현상 확인하여 크기 수정
- 모바일모드에서 잼 상세페이지 타이틀 옆에 모집상태 버튼 모집완료 상태에서 뭉개지는 현상 수정
- 잼 상세페이지에서 잼 정보 아이콘 목록들이 글자가 뭉개지지 않고 아이콘 목록단위로 다음줄로 떨어지도록 수정
- 그외 : 지난번 작업후 키워드 검색 모달 마운트시 콘솔에 뜨는 오류 수정

## 스크린샷
![image](https://user-images.githubusercontent.com/97942837/208577312-732c97d3-d4bf-4ec8-8e93-e1fb3cf0e314.png)
![image](https://user-images.githubusercontent.com/97942837/208577562-290dd836-bc61-45a2-983d-ef72d269e91e.png)
![image](https://user-images.githubusercontent.com/97942837/208578127-991d248d-7cd9-44f2-a82d-4f45a5777003.png)
![image](https://user-images.githubusercontent.com/97942837/208577968-b3ff8aa5-b5b1-4a59-a5b3-8d5a212da70a.png)
