### PR TITLE
[client] 잼 상세페이지 스터디 위치 오버레이 수정

### DIFF
--- a/client/src/Components/jamDetailComponent/JamLocationMap.js
+++ b/client/src/Components/jamDetailComponent/JamLocationMap.js
@@ -48,9 +48,7 @@ const JamLocationMap = ({ jamData }) => {
       yAnchor: -2,
     });
 
-    kakao.maps.event.addListener(marker, 'mouseover', function () {
-      overlay.setMap(map);
-    });
+    overlay.setMap(map);
 
     kakao.maps.event.addListener(marker, 'mouseout', function () {
       overlay.setMap(null);


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
잼 상세페이지 지도 부분에서 스터디 위치를 나타내는 오버레이를 (호버시에 보여주지 않고) 바로 보여주도록 수정
(모바일 모드에서 호버 기능의 호환성이 부족한 부분 반영)

## 스크린샷
![image](https://user-images.githubusercontent.com/97942837/209329645-22f31180-4526-4daf-a6a2-af555fbb2d33.png)
