### PR TITLE
[client] 모바일 검색페이지에 최근 검색어 기록 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12505,6 +12505,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
+      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==",
+      "peer": true
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -17500,6 +17506,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -27470,6 +27489,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
+      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==",
+      "peer": true
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -30947,6 +30972,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.32",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12505,12 +12505,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
-      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==",
-      "peer": true
-    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -17506,19 +17500,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -27489,12 +27470,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
-      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A==",
-      "peer": true
-    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -30972,12 +30947,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.32",

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -71,6 +71,10 @@ const label = css`
   font-weight: bold;
 `;
 
+const setSessionStorageItem = (key, value) => {
+  sessionStorage.setItem('searchText', value);
+};
+
 const setLocalStorageItem = (key, value) => {
   localStorage.setItem(key, JSON.stringify(value));
 };
@@ -88,6 +92,7 @@ const SearchBar = () => {
 
   const handleSubmit = () => {
     setLocalStorageItem('searchText', searchText);
+    setSessionStorageItem('searchText', searchText);
     const tempList = JSON.parse(getLocalStorageItem('SearchTextList') || '[]');
     tempList.push(searchText);
     setLocalStorageItem('SearchTextList', tempList);

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -130,7 +130,9 @@ const BackBtn = () => {
 
 const SearchKeywords = () => {
   const [searchedTextList, setSearchedTextList] = useState(
-    JSON.parse(getLocalStorageItem('SearchTextList')).reverse(),
+    getLocalStorageItem('SearchTextList')
+      ? JSON.parse(getLocalStorageItem('SearchTextList')).reverse()
+      : [],
   );
 
   const handleDeleteBtnClick = keyword => {

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -59,7 +59,6 @@ const searchBar = css`
 const keywordList = css`
   margin: 20px;
   li {
-    background-color: beige;
     margin: 5px;
     padding: 10px;
     display: flex;
@@ -123,7 +122,9 @@ const BackBtn = () => {
 };
 
 const SearchKeywords = () => {
-  const searchedTextList = JSON.parse(localStorage.getItem('SearchTextList'));
+  const searchedTextList = JSON.parse(
+    localStorage.getItem('SearchTextList'),
+  ).reverse();
   return (
     <div className={keywordList}>
       <ul>

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -1,16 +1,12 @@
 import { css } from '@emotion/css';
 import { useNavigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { BiSearch } from 'react-icons/bi';
 import { styled } from '@mui/material/styles';
 import InputBase from '@mui/material/InputBase';
 import { IconButton } from '@material-ui/core';
-import { MdArrowBackIosNew } from 'react-icons/md';
+import { MdArrowBackIosNew, MdOutlineClose } from 'react-icons/md';
 import { palette } from '../Styles/theme';
-import LongJamCard from '../Components/Card/LongJamCard';
-import { fetchJamRead } from '../Utils/fetchJam';
-import { NoNearyByData } from '../Components/NoData';
-import { list } from './Home';
 
 const SearchContainer = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -60,8 +56,15 @@ const searchBar = css`
   flex-grow: 1;
 `;
 
-const jamList = css`
-  margin: 10px;
+const keywordList = css`
+  margin: 20px;
+  li {
+    background-color: beige;
+    margin: 5px;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+  }
 `;
 
 const label = css`
@@ -71,13 +74,17 @@ const label = css`
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
-
   const handleSearch = e => {
     setSearchText(e.target.value);
   };
 
   const handleSubmit = () => {
     sessionStorage.setItem('searchText', searchText);
+    const searchedTextList = JSON.parse(
+      localStorage.getItem('SearchTextList') || '[]',
+    );
+    searchedTextList.push(searchText);
+    localStorage.setItem('SearchTextList', JSON.stringify(searchedTextList));
     navigate('/category');
   };
 
@@ -114,40 +121,32 @@ const BackBtn = () => {
     </div>
   );
 };
+
+const SearchKeywords = () => {
+  const searchedTextList = JSON.parse(localStorage.getItem('SearchTextList'));
+  return (
+    <div className={keywordList}>
+      <ul>
+        {searchedTextList &&
+          searchedTextList.map((el, idx) => (
+            <li key={idx}>
+              {el}
+              <MdOutlineClose />
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+};
 const Search = () => {
-  const [jamData, setJamData] = useState([]);
-  useEffect(() => {
-    const endpoint = `/jams`;
-    const locateJams = fetchJamRead(endpoint);
-    locateJams.then(data => {
-      setJamData(
-        data.content
-          .filter(el => el.completeStatus === 'FALSE')
-          .sort((a, b) => a.jamTo.localeCompare(b.jamTo)),
-      );
-    });
-  }, []);
   return (
     <div>
       <nav className={container}>
         <BackBtn />
         <SearchBar />
       </nav>
-      <p className={label}>마감이 가까운 잼이에요</p>
-      <div className={jamList}>
-        {jamData ? (
-          <div className={list}>
-            {jamData &&
-              jamData.map(jam => {
-                return <LongJamCard key={jam.jamId} jam={jam} />;
-              })}
-          </div>
-        ) : (
-          <div className={list}>
-            <NoNearyByData />
-          </div>
-        )}
-      </div>
+      <p className={label}>최근 검색한 키워드예요</p>
+      <SearchKeywords />
     </div>
   );
 };

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -82,6 +82,7 @@ const getLocalStorageItem = key => {
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
+  setLocalStorageItem('SearchTextList', []);
   const handleSearch = e => {
     setSearchText(e.target.value);
   };

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -70,6 +70,15 @@ const label = css`
   margin: 20px;
   font-weight: bold;
 `;
+
+const setLocalStorageItem = (key, value) => {
+  localStorage.setItem(key, JSON.stringify(value));
+};
+
+const getLocalStorageItem = key => {
+  return localStorage.getItem(key);
+};
+
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
@@ -78,12 +87,10 @@ const SearchBar = () => {
   };
 
   const handleSubmit = () => {
-    sessionStorage.setItem('searchText', searchText);
-    const searchedTextList = JSON.parse(
-      localStorage.getItem('SearchTextList') || '[]',
-    );
-    searchedTextList.push(searchText);
-    localStorage.setItem('SearchTextList', JSON.stringify(searchedTextList));
+    setLocalStorageItem('searchText', searchText);
+    const tempList = JSON.parse(getLocalStorageItem('SearchTextList') || '[]');
+    tempList.push(searchText);
+    setLocalStorageItem('SearchTextList', tempList);
     navigate('/category');
   };
 
@@ -122,9 +129,16 @@ const BackBtn = () => {
 };
 
 const SearchKeywords = () => {
-  const searchedTextList = JSON.parse(
-    localStorage.getItem('SearchTextList'),
-  ).reverse();
+  const [searchedTextList, setSearchedTextList] = useState(
+    JSON.parse(getLocalStorageItem('SearchTextList')).reverse(),
+  );
+
+  const handleDeleteBtnClick = keyword => {
+    const deletedList = searchedTextList.filter(v => v !== keyword);
+    setLocalStorageItem('SearchTextList', deletedList);
+    setSearchedTextList(deletedList);
+  };
+
   return (
     <div className={keywordList}>
       <ul>
@@ -132,7 +146,13 @@ const SearchKeywords = () => {
           searchedTextList.map((el, idx) => (
             <li key={idx}>
               {el}
-              <MdOutlineClose />
+              <button
+                key={idx}
+                type="button"
+                onClick={() => handleDeleteBtnClick(el)}
+              >
+                <MdOutlineClose />
+              </button>
             </li>
           ))}
       </ul>

--- a/client/src/Pages/Search.js
+++ b/client/src/Pages/Search.js
@@ -82,7 +82,6 @@ const getLocalStorageItem = key => {
 const SearchBar = () => {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
-  setLocalStorageItem('SearchTextList', []);
   const handleSearch = e => {
     setSearchText(e.target.value);
   };


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
localstorage를 이용해 모바일용 검색 페이지 하단에 최근 검색어 기능을 추가했습니다.
- 마지막으로 검색한 검색어가 가장 상단에 오도록 정렬했습니다.
- 오른쪽 x 아이콘을 클릭해 삭제하는 기능을 추가했습니다.

## 스크린샷
![Kapture 2023-01-06 at 14 52 55](https://user-images.githubusercontent.com/53070295/210939203-efbb3fe5-08ee-4cb3-9ba1-2aee78bcbbfe.gif)

