### PR TITLE
[client] 잼 상세페이지 동적 라우트 임의 접근시 오류 처리 및 맵 오버레이 오류 수정

### DIFF
--- a/client/src/Components/jamDetailComponent/JamLocationMap.js
+++ b/client/src/Components/jamDetailComponent/JamLocationMap.js
@@ -49,10 +49,7 @@ const JamLocationMap = ({ jamData }) => {
     });
 
     overlay.setMap(map);
-
-    kakao.maps.event.addListener(marker, 'mouseout', function () {
-      overlay.setMap(null);
-    });
+    marker.setMap(map);
   };
 
   useEffect(() => {

--- a/client/src/Pages/JamDetail.js
+++ b/client/src/Pages/JamDetail.js
@@ -3,7 +3,7 @@
 /** @jsxImportSource @emotion/react */
 /* eslint-disable react/prop-types */
 import React, { useState, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { css } from '@emotion/react';
 import { ThemeProvider } from '@mui/material';
@@ -127,6 +127,7 @@ const JamDetail = ({ setIsEdit }) => {
   const [isComplete, setIsComplete] = useState('');
   const [joiner, setJoiner] = useState([]);
   const { id } = useParams();
+  const navigate = useNavigate();
 
   const [replyData, setReplyData] = useState([]);
 
@@ -135,11 +136,21 @@ const JamDetail = ({ setIsEdit }) => {
   // eslint-disable-next-line no-shadow
   const getJamData = async () => {
     // eslint-disable-next-line no-return-await
-    await axios.get(`${BASE_URL}/jams/${id}`).then(res => {
-      setJamData({ ...res.data });
-      setIsComplete({ ...res.data }.completeStatus);
-      setJoiner({ ...res.data }.participantList);
-    });
+    await axios
+      .get(`${BASE_URL}/jams/${id}`, { validateStatus: false })
+      .then(res => {
+        if (res.status === 404) {
+          navigate('*');
+          setTimeout(() => {
+            alert('잘못된 접근입니다. 메인페이지로 이동합니다.');
+            navigate('/');
+          }, 3000);
+        } else {
+          setJamData({ ...res.data });
+          setIsComplete({ ...res.data }.completeStatus);
+          setJoiner({ ...res.data }.participantList);
+        }
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## PR 전 확인 사항
- [x]  오른쪽 브랜치: feat 브랜치
- [x]  왼쪽 브랜치: dev 브랜치
- [x]  커밋 컨벤션 일치 여부

## PR 내용
- 잼 상세페이지 동적 라우트 경로에서 존재하지 않는 id로 임의 접근시 잘못된 페이지로 안내하고 메인페이지로 돌아가도록 수정
- 잼 상세페이지 스터디 위치를 맵상에서 나타내는 오버레이가 호버시 사라지는 현상을 발견하여 계속 보여지도록 수정

## 스크린샷
![잘못된페이지적용](https://user-images.githubusercontent.com/97942837/210949069-fb340d73-982a-4fdf-ba69-709a03bd5b13.gif)
